### PR TITLE
Condenses navbar options to fit the space better

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,9 +347,3 @@ DEPENDENCIES
   web-console (~> 2.0)
   webmock
   will_paginate
-
-RUBY VERSION
-   ruby 2.2.2p95
-
-BUNDLED WITH
-   1.15.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,3 +347,9 @@ DEPENDENCIES
   web-console (~> 2.0)
   webmock
   will_paginate
+
+RUBY VERSION
+   ruby 2.2.2p95
+
+BUNDLED WITH
+   1.15.1

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -79,7 +79,6 @@ input[type="submit"] {
 
 /* NAV BAR ONLY */
 .search-form-header {
-  width: auto;
   margin-right: 10px;
   margin-bottom: 10px;
   margin-top: 10px;

--- a/app/assets/stylesheets/layouts.scss
+++ b/app/assets/stylesheets/layouts.scss
@@ -20,6 +20,6 @@
 
 
 #header-movie-search input {
-  width: 300px;
+  width: 250px;
   margin-left: 40px;
 }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -36,7 +36,7 @@
         </li><!-- dropdown button -->
       <% if current_user.present? %>
         <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Lists <span class="caret"></span></a>
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">My Lists <span class="caret"></span></a>
           <ul class="dropdown-menu">
             <li><%= link_to 'My Movies', movies_path, id: "my_movies_nav_link" %></li>
             <li><%= link_to 'Public Lists', public_lists_path, id: "public_lists_nav_link" %></li>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -38,7 +38,7 @@
         <li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Lists <span class="caret"></span></a>
           <ul class="dropdown-menu">
-            <li><%= link_to 'Recently Watched', movies_path, id: "my_movies_nav_link" %></li>
+            <li><%= link_to 'My Movies', movies_path, id: "my_movies_nav_link" %></li>
             <li><%= link_to 'Public Lists', public_lists_path, id: "public_lists_nav_link" %></li>
             <li role="separator" class="divider"></li>
             <% current_user.all_lists_by_name.each do |list| %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -19,7 +19,8 @@
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= "Signed in as: #{current_user.username}" %> <span class="caret"></span></a>
           <ul class="dropdown-menu">
             <li><%= link_to 'Sign Out', destroy_user_session_path, :method => :delete, id: "sign_out_nav_link" %></li>
-            <li><%= link_to 'Profile', user_path(current_user), id: "profile_nav_link" %></li>
+            <li><%= link_to 'Profile Settings', user_path(current_user), id: "profile_nav_link" %></li>
+            <li><%= link_to 'Manage My Lists', user_lists_path(current_user), id: "my_lists_nav_link" %></li>
           </ul><!-- dropdown items -->
         </li><!-- dropdown button -->
       </ul><!-- nav navbar-nav navbar-right -->
@@ -34,19 +35,17 @@
           </ul> <!-- dropdown items -->
         </li><!-- dropdown button -->
       <% if current_user.present? %>
-        <li><%= link_to 'My Movies', movies_path, id: "my_movies_nav_link" %></li>
         <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">My Lists <span class="caret"></span></a>
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Lists <span class="caret"></span></a>
           <ul class="dropdown-menu">
+            <li><%= link_to 'Recently Watched', movies_path, id: "my_movies_nav_link" %></li>
+            <li><%= link_to 'Public Lists', public_lists_path, id: "public_lists_nav_link" %></li>
+            <li role="separator" class="divider"></li>
             <% current_user.all_lists_by_name.each do |list| %>
               <li><%= link_to "#{list.name}", user_list_path(list.owner, list) %></li>
             <% end %><!-- lists.each -->
-            <li role="separator" class="divider"></li>
-            <li><%= link_to 'Manage My Lists', user_lists_path(current_user), id: "my_lists_nav_link" %></li>
-            <li><%= link_to '<i class="fa fa-plus"></i> New List'.html_safe, new_user_list_path(current_user) %></li>
           </ul> <!-- dropdown items -->
         </li><!-- dropdown button -->
-        <li><%= link_to 'Public Lists', public_lists_path, id: "public_lists_nav_link" %></li>
 
         <li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Search Options <span class="caret"></span></a>


### PR DESCRIPTION
Old navbar has an annoying line break
<img width="1076" alt="screenshot 2017-12-28 00 00 33" src="https://user-images.githubusercontent.com/8680712/34401669-36df0fee-eb62-11e7-91cc-52730829d86f.png">

New navbar fits on one line, not perfectly, but better
<img width="944" alt="screenshot 2017-12-28 00 00 21" src="https://user-images.githubusercontent.com/8680712/34401668-36932066-eb62-11e7-9369-5fedcf63cf92.png">

Moved nav items as such:
- "My Lists" -> "Lists"
- "My Movies" -> Lists/Recently Watched
- "Public Lists" -> Lists/Public Lists
- "Lists/Manage My Lists" -> signed in as:... / Manage My Lists since we rarely use this feature
- "Lists/Add a List" -> removed from nav, now just a link on the My Lists index page
 
<img width="174" alt="screenshot 2017-12-28 00 02 18" src="https://user-images.githubusercontent.com/8680712/34401707-6d6dfc32-eb62-11e7-8ea0-b7e8c038f4f1.png">

<img width="184" alt="screenshot 2017-12-28 00 02 25" src="https://user-images.githubusercontent.com/8680712/34401708-6d7df02e-eb62-11e7-8a6d-f8de346b43c3.png">

Be advised... I didn't run the test suite or anything. :0
