### PR TITLE
Upgrades FactoryGirl to FactoryBot gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,25 @@
+require: rubocop-rspec
+
+Documentation:
+  Enabled: false
+Rails:
+  Enabled: true
+AllCops:
+  DefaultFormatter: progress
+  Exclude:
+    - spec/rails_helper.rb
+    - spec/spec_helper.rb
+    - 'bin/**'
+    - 'config/**/*'
+    - 'db/**/*'
+    - 'script/**/*'
+Metrics/BlockLength:
+  Exclude:
+    - !ruby/regexp /.*_spec\.rb$/
+Metrics/LineLength:
+  Max: 99
+Style/BlockDelimiters:
+  Exclude:
+    - !ruby/regexp /.*_spec\.rb$/
+Style/EmptyMethod:
+  EnforcedStyle: expanded

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,8 @@ group :development, :test do
   gem 'awesome_print'
   gem 'quiet_assets'
   gem 'rspec-rails', '~> 3.0'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
+  gem 'rubocop-rspec'
   gem 'letter_opener'
   gem 'capybara-email'
   gem 'guard-rspec', require: false
@@ -37,7 +38,6 @@ group :development, :test do
   gem 'spring-commands-rspec'
   gem 'web-console', '~> 2.0'
   gem 'spring'
-
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.8)
     arel (6.0.3)
+    ast (2.4.0)
     awesome_print (1.6.1)
     bcrypt (3.1.10)
     binding_of_caller (0.7.2)
@@ -87,10 +88,10 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
-    factory_girl (4.5.0)
+    factory_bot (4.11.0)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.5.0)
-      factory_girl (~> 4.5.0)
+    factory_bot_rails (4.11.0)
+      factory_bot (~> 4.11.0)
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -120,6 +121,7 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
+    jaro_winkler (1.5.1)
     jbuilder (2.3.2)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
@@ -156,7 +158,11 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     orm_adapter (0.5.0)
+    parallel (1.12.1)
+    parser (2.5.1.2)
+      ast (~> 2.4.0)
     pg (0.18.4)
+    powerpack (0.1.2)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -198,6 +204,7 @@ GEM
       activesupport (= 4.2.3)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (3.0.0)
     rake (10.4.2)
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
@@ -230,6 +237,17 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
+    rubocop (0.58.2)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    rubocop-rspec (1.29.1)
+      rubocop (>= 0.58.0)
+    ruby-progressbar (1.10.0)
     rubyzip (1.1.7)
     safe_yaml (1.0.4)
     sass (3.4.19)
@@ -287,6 +305,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
+    unicode-display_width (1.4.0)
     vcr (2.9.3)
     warden (1.2.3)
       rack (>= 1.0)
@@ -314,7 +333,7 @@ DEPENDENCIES
   coveralls
   database_cleaner
   devise
-  factory_girl_rails
+  factory_bot_rails
   ffaker
   figaro
   friendly_id
@@ -332,6 +351,7 @@ DEPENDENCIES
   rails (= 4.2.3)
   rails_12factor
   rspec-rails (~> 3.0)
+  rubocop-rspec
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   selenium-webdriver
@@ -352,4 +372,4 @@ RUBY VERSION
    ruby 2.2.2p95
 
 BUNDLED WITH
-   1.15.1
+   1.16.1

--- a/spec/controllers/invites_controller_spec.rb
+++ b/spec/controllers/invites_controller_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe InvitesController, type: :controller do
 
-  let(:user1) { FactoryGirl.create(:user) }
-  let(:user2) { FactoryGirl.create(:user) }
-  let(:list) { FactoryGirl.create(:list) }
+  let(:user1) { FactoryBot.create(:user) }
+  let(:user2) { FactoryBot.create(:user) }
+  let(:list) { FactoryBot.create(:list) }
   let(:receiver_email) { FFaker::Internet.email }
-  let(:invite) { FactoryGirl.build(:invite, list_id: list.id, email: receiver_email, sender_id: user1.id) }
-  let(:invalid_invite) { FactoryGirl.build(:invalid_invite, list_id: list.id, sender_id: user1.id) }
+  let(:invite) { FactoryBot.build(:invite, list_id: list.id, email: receiver_email, sender_id: user1.id) }
+  let(:invalid_invite) { FactoryBot.build(:invalid_invite, list_id: list.id, sender_id: user1.id) }
   let(:current_user) { login_with user1 }
   let(:invalid_user) { login_with nil }
   let(:valid_attributes) { invite.attributes }

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -2,18 +2,18 @@ require 'rails_helper'
 
 RSpec.describe ListingsController, type: :controller do
 
-  let(:user) { FactoryGirl.create(:user) }
-  let(:user2) { FactoryGirl.create(:user) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:user2) { FactoryBot.create(:user) }
   let(:current_user) { login_with user }
   let(:current_user2) { login_with user2 }
   let(:invalid_user) { login_with nil }
-  let(:movie) { FactoryGirl.create(:movie) }
-  let(:movie2) { FactoryGirl.create(:movie) }
-  let(:list) { FactoryGirl.create(:list, owner_id: user.id) }
+  let(:movie) { FactoryBot.create(:movie) }
+  let(:movie2) { FactoryBot.create(:movie) }
+  let(:list) { FactoryBot.create(:list, owner_id: user.id) }
   let(:tmdb_id) { movie.tmdb_id }
   let(:tmdb_id2) { movie2.tmdb_id }
   let(:valid_attributes) { {tmdb_id: tmdb_id} }
-  let(:listing) { FactoryGirl.create(:listing, movie_id: movie.id, list_id: list.id, user_id: user.id) }
+  let(:listing) { FactoryBot.create(:listing, movie_id: movie.id, list_id: list.id, user_id: user.id) }
 
 
   shared_examples_for "logged in access" do

--- a/spec/controllers/lists_controller_spec.rb
+++ b/spec/controllers/lists_controller_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe ListsController, type: :controller do
 
   let(:list_name) { SecureRandom.urlsafe_base64(10) }
-  let(:user) { FactoryGirl.create(:user) }
-  let(:user2) { FactoryGirl.create(:user) }
-  let(:list) { FactoryGirl.create(:list, :owner => user) }
-  let(:list2) { FactoryGirl.create(:list, :owner => user2) }
-  let(:public_list) { FactoryGirl.create(:list, :owner => user, :is_public => true) }
-  let(:invalid_list) { FactoryGirl.create(:invalid_list) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:user2) { FactoryBot.create(:user) }
+  let(:list) { FactoryBot.create(:list, :owner => user) }
+  let(:list2) { FactoryBot.create(:list, :owner => user2) }
+  let(:public_list) { FactoryBot.create(:list, :owner => user, :is_public => true) }
+  let(:invalid_list) { FactoryBot.create(:invalid_list) }
   let(:current_user) { login_with user }
   let(:current_user2) { login_with user2 }
   let(:invalid_user) { login_with nil }
@@ -112,7 +112,7 @@ RSpec.describe ListsController, type: :controller do
 
     describe "PUT #update" do
       context "with valid params" do
-        let(:new_attributes) { FactoryGirl.attributes_for(:list, name: "zibbler") }
+        let(:new_attributes) { FactoryBot.attributes_for(:list, name: "zibbler") }
 
         it "updates the requested list" do
           put :update, { user_id: user.to_param, :id => list.to_param, :list => new_attributes }
@@ -205,7 +205,7 @@ RSpec.describe ListsController, type: :controller do
 
     describe "PUT #update" do
       context "with valid params" do
-        let(:new_attributes) { FactoryGirl.attributes_for(:list, name: "zibbler", description: "zag nuts") }
+        let(:new_attributes) { FactoryBot.attributes_for(:list, name: "zibbler", description: "zag nuts") }
 
         before(:example) do
           put :update, { user_id: user.to_param, :id => list.to_param, :list => new_attributes }
@@ -216,7 +216,7 @@ RSpec.describe ListsController, type: :controller do
 
       context "with invalid params" do
         before(:example) do
-          put :update, { user_id: user.to_param, :id => list.to_param, :list => FactoryGirl.attributes_for(:invalid_list)}
+          put :update, { user_id: user.to_param, :id => list.to_param, :list => FactoryBot.attributes_for(:invalid_list)}
         end
         it { is_expected.to redirect_to new_user_session_path }
       end
@@ -274,7 +274,7 @@ RSpec.describe ListsController, type: :controller do
 
     describe "PUT #update" do
       context "with valid params" do
-        let(:new_attributes) { FactoryGirl.attributes_for(:list, name: "zibbler") }
+        let(:new_attributes) { FactoryBot.attributes_for(:list, name: "zibbler") }
 
         before(:example) do
           put :update, { user_id: user2.to_param, :id => list2.to_param, :list => new_attributes }
@@ -285,7 +285,7 @@ RSpec.describe ListsController, type: :controller do
 
       context "with invalid params" do
         before(:example) do
-          put :update, { user_id: user2.to_param, :id => list2.to_param, :list => FactoryGirl.attributes_for(:invalid_list) }
+          put :update, { user_id: user2.to_param, :id => list2.to_param, :list => FactoryBot.attributes_for(:invalid_list) }
         end
         it { is_expected.to redirect_to user_lists_path(user) }
       end

--- a/spec/controllers/ratings_controller_spec.rb
+++ b/spec/controllers/ratings_controller_spec.rb
@@ -4,20 +4,20 @@ require 'rails_helper'
 RSpec.describe RatingsController, type: :controller do
 
 
-  let(:user) { FactoryGirl.create(:user) }
-  let(:user2) { FactoryGirl.create(:user) }
-  let(:list) { FactoryGirl.create(:list, :owner => user) }
-  let(:list2) { FactoryGirl.create(:list, :owner => user2) }
-  let(:movie)  { FactoryGirl.create(:movie) }
-  let(:movie2)  { FactoryGirl.create(:movie) }
-  let(:movie3)  { FactoryGirl.create(:movie) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:user2) { FactoryBot.create(:user) }
+  let(:list) { FactoryBot.create(:list, :owner => user) }
+  let(:list2) { FactoryBot.create(:list, :owner => user2) }
+  let(:movie)  { FactoryBot.create(:movie) }
+  let(:movie2)  { FactoryBot.create(:movie) }
+  let(:movie3)  { FactoryBot.create(:movie) }
   let(:current_user) { login_with user }
   let(:current_user2) { login_with user2 }
   let(:invalid_user) { login_with nil }
-  let(:listing) { FactoryGirl.create(:listing, list_id: list.id, movie_id: movie.id) }
-  let(:rating) { FactoryGirl.create(:rating, user_id: user.id, movie_id: movie.id, value: 8) }
-  let(:rating2) { FactoryGirl.create(:rating, user_id: user2.id, movie_id: movie.id) }
-  let(:invalid_rating) { FactoryGirl.build(:invalid_rating) }
+  let(:listing) { FactoryBot.create(:listing, list_id: list.id, movie_id: movie.id) }
+  let(:rating) { FactoryBot.create(:rating, user_id: user.id, movie_id: movie.id, value: 8) }
+  let(:rating2) { FactoryBot.create(:rating, user_id: user2.id, movie_id: movie.id) }
+  let(:invalid_rating) { FactoryBot.build(:invalid_rating) }
   let(:invalid_attributes) { invalid_rating.attributes }
 
 
@@ -86,7 +86,7 @@ RSpec.describe RatingsController, type: :controller do
 
     describe "PUT #update" do
       context "with valid params" do
-        let(:new_attributes) { FactoryGirl.attributes_for(:rating, value: 2) }
+        let(:new_attributes) { FactoryBot.attributes_for(:rating, value: 2) }
 
         it "updates the requested rating" do
           put :update, { :movie_id => movie.id, :id => rating.to_param, :rating => new_attributes }
@@ -181,7 +181,7 @@ RSpec.describe RatingsController, type: :controller do
 
     describe "PUT #update" do
       context "with valid params" do
-        let(:new_attributes) { FactoryGirl.attributes_for(:rating, value: 5) }
+        let(:new_attributes) { FactoryBot.attributes_for(:rating, value: 5) }
 
         before(:example) do
           put :update, { :movie_id => movie.id, :id => rating.to_param, :rating => new_attributes }
@@ -231,7 +231,7 @@ RSpec.describe RatingsController, type: :controller do
 
     describe "PUT #update" do
       context "with valid params" do
-        let(:new_attributes) { FactoryGirl.attributes_for(:rating, value: 5) }
+        let(:new_attributes) { FactoryBot.attributes_for(:rating, value: 5) }
         before(:example) do
           put :update, { :movie_id => movie.id, :id => rating2.to_param, :rating => new_attributes }
         end

--- a/spec/controllers/reviews_controller_spec.rb
+++ b/spec/controllers/reviews_controller_spec.rb
@@ -4,23 +4,23 @@ require 'rails_helper'
 RSpec.describe ReviewsController, type: :controller do
 
 
-  let(:user) { FactoryGirl.create(:user) }
-  let(:user2) { FactoryGirl.create(:user) }
-  let(:list) { FactoryGirl.create(:list, :owner => user) }
-  let(:list2) { FactoryGirl.create(:list, :owner => user2) }
-  let(:movie)  { FactoryGirl.create(:movie) }
-  let(:movie1)  { FactoryGirl.create(:movie) }
-  let(:movie2)  { FactoryGirl.create(:movie) }
-  let(:movie3) { FactoryGirl.create(:movie) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:user2) { FactoryBot.create(:user) }
+  let(:list) { FactoryBot.create(:list, :owner => user) }
+  let(:list2) { FactoryBot.create(:list, :owner => user2) }
+  let(:movie)  { FactoryBot.create(:movie) }
+  let(:movie1)  { FactoryBot.create(:movie) }
+  let(:movie2)  { FactoryBot.create(:movie) }
+  let(:movie3) { FactoryBot.create(:movie) }
   let(:current_user) { login_with user }
   let(:current_user2) { login_with user2 }
   let(:invalid_user) { login_with nil }
-  let(:listing) { FactoryGirl.create(:listing, list_id: list.id, movie_id: movie.id) }
-  let(:listing2) { FactoryGirl.create(:listing, list_id: list.id, movie_id: movie2.id) }
-  let(:listing3) { FactoryGirl.create(:listing, list_id: list.id, movie_id: movie3.id) }
-  let(:review) { FactoryGirl.create(:review, user_id: user.id, movie_id: movie.id) }
-  let(:review2) { FactoryGirl.create(:review, user_id: user2.id, movie_id: movie.id) }
-  let(:invalid_review) { FactoryGirl.build(:invalid_review) }
+  let(:listing) { FactoryBot.create(:listing, list_id: list.id, movie_id: movie.id) }
+  let(:listing2) { FactoryBot.create(:listing, list_id: list.id, movie_id: movie2.id) }
+  let(:listing3) { FactoryBot.create(:listing, list_id: list.id, movie_id: movie3.id) }
+  let(:review) { FactoryBot.create(:review, user_id: user.id, movie_id: movie.id) }
+  let(:review2) { FactoryBot.create(:review, user_id: user2.id, movie_id: movie.id) }
+  let(:invalid_review) { FactoryBot.build(:invalid_review) }
   let(:valid_attributes) { review.attributes }
   let(:invalid_attributes) { invalid_review.attributes }
 
@@ -90,7 +90,7 @@ RSpec.describe ReviewsController, type: :controller do
 
     describe "PUT #update" do
       context "with valid params" do
-        let(:new_attributes) { FactoryGirl.attributes_for(:review, body: "epic movie!") }
+        let(:new_attributes) { FactoryBot.attributes_for(:review, body: "epic movie!") }
 
         it "updates the requested review" do
           put :update, { :movie_id => movie.id, :id => review.to_param, :review => new_attributes }
@@ -185,7 +185,7 @@ RSpec.describe ReviewsController, type: :controller do
 
     describe "PUT #update" do
       context "with valid params" do
-        let(:new_attributes) { FactoryGirl.attributes_for(:review, value: '5') }
+        let(:new_attributes) { FactoryBot.attributes_for(:review, value: '5') }
 
         before(:example) do
           put :update, { :movie_id => movie.id, :id => review.to_param, :review => new_attributes }
@@ -235,7 +235,7 @@ RSpec.describe ReviewsController, type: :controller do
 
     describe "PUT #update" do
       context "with valid params" do
-        let(:new_attributes) { FactoryGirl.attributes_for(:review, body: 'it was teh bestest') }
+        let(:new_attributes) { FactoryBot.attributes_for(:review, body: 'it was teh bestest') }
         before(:example) do
           put :update, { :movie_id => movie.id, :id => review2.to_param, :rating => new_attributes }
         end

--- a/spec/controllers/screenings_controller_spec.rb
+++ b/spec/controllers/screenings_controller_spec.rb
@@ -4,18 +4,18 @@ require 'rails_helper'
 RSpec.describe ScreeningsController, type: :controller do
 
 
-  let(:user) { FactoryGirl.create(:user) }
-  let(:user2) { FactoryGirl.create(:user) }
-  let(:list) { FactoryGirl.create(:list, :owner => user) }
-  let(:list2) { FactoryGirl.create(:list, :owner => user2) }
-  let(:movie)  { FactoryGirl.create(:movie) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:user2) { FactoryBot.create(:user) }
+  let(:list) { FactoryBot.create(:list, :owner => user) }
+  let(:list2) { FactoryBot.create(:list, :owner => user2) }
+  let(:movie)  { FactoryBot.create(:movie) }
   let(:current_user) { login_with user }
   let(:current_user2) { login_with user2 }
   let(:invalid_user) { login_with nil }
-  let(:listing) { FactoryGirl.create(:listing, list_id: list.id, movie_id: movie.id) }
-  let(:screening) { FactoryGirl.create(:screening, user_id: user.id, movie_id: movie.id) }
-  let(:screening2) { FactoryGirl.create(:screening, user_id: user2.id, movie_id: movie.id) }
-  let(:invalid_screening) { FactoryGirl.build(:invalid_screening) }
+  let(:listing) { FactoryBot.create(:listing, list_id: list.id, movie_id: movie.id) }
+  let(:screening) { FactoryBot.create(:screening, user_id: user.id, movie_id: movie.id) }
+  let(:screening2) { FactoryBot.create(:screening, user_id: user2.id, movie_id: movie.id) }
+  let(:invalid_screening) { FactoryBot.build(:invalid_screening) }
   let(:valid_attributes) { screening.attributes }
   let(:invalid_attributes) { invalid_screening.attributes }
 
@@ -81,7 +81,7 @@ RSpec.describe ScreeningsController, type: :controller do
 
     describe "PUT #update" do
       context "with valid params" do
-        let(:new_attributes) { FactoryGirl.attributes_for(:screening, notes: "epic notes!") }
+        let(:new_attributes) { FactoryBot.attributes_for(:screening, notes: "epic notes!") }
 
         it "updates the requested screening" do
           put :update, { :movie_id => movie.id, :id => screening.to_param, :screening => new_attributes }
@@ -170,7 +170,7 @@ RSpec.describe ScreeningsController, type: :controller do
 
     describe "PUT #update" do
       context "with valid params" do
-        let(:new_attributes) { FactoryGirl.attributes_for(:screening, notes: "epic notes!") }
+        let(:new_attributes) { FactoryBot.attributes_for(:screening, notes: "epic notes!") }
 
         before(:example) do
           put :update, { :movie_id => movie.id, :id => screening.to_param, :screening => new_attributes }
@@ -223,7 +223,7 @@ RSpec.describe ScreeningsController, type: :controller do
 
     describe "PUT #update" do
       context "with valid params" do
-        let(:new_attributes) { FactoryGirl.attributes_for(:screening, notes: "epic notes!") }
+        let(:new_attributes) { FactoryBot.attributes_for(:screening, notes: "epic notes!") }
 
         it "it raises an exception if user tries to update another users's screening"  do
           expect {

--- a/spec/controllers/taggings_controller_spec.rb
+++ b/spec/controllers/taggings_controller_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe TaggingsController, type: :controller do
 
-  let(:user) { FactoryGirl.create(:user) }
+  let(:user) { FactoryBot.create(:user) }
   let(:current_user) { login_with user }
   let(:invalid_user) { login_with nil }
-  let(:movie) { FactoryGirl.create(:movie) }
+  let(:movie) { FactoryBot.create(:movie) }
   let(:tag_list) { "funny, scary" }
-  let(:tag) { FactoryGirl.create(:tag) }
-  let(:tagging) { FactoryGirl.create(:tagging, tag_id: tag.id, movie_id: movie.id, user_id: user.id) }
+  let(:tag) { FactoryBot.create(:tag) }
+  let(:tagging) { FactoryBot.create(:tagging, tag_id: tag.id, movie_id: movie.id, user_id: user.id) }
 
   context 'with a logged in user' do
 

--- a/spec/controllers/tmdb_controller_spec.rb
+++ b/spec/controllers/tmdb_controller_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe TmdbController, type: :controller do
 
-  let(:user) { FactoryGirl.create(:user) }
+  let(:user) { FactoryBot.create(:user) }
   let(:current_user) { login_with user }
   let(:invalid_user) { login_with nil }
-  let(:movie) { FactoryGirl.create(:movie) }
+  let(:movie) { FactoryBot.create(:movie) }
 
   context 'with a logged in user' do
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe UsersController, type: :controller do
 
-  let(:user) { FactoryGirl.create(:user) }
-  let(:user2) { FactoryGirl.create(:user) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:user2) { FactoryBot.create(:user) }
   let(:current_user) { login_with user }
   let(:current_user2) { login_with user2 }
   let(:invalid_user) { login_with nil }

--- a/spec/factories/invites.rb
+++ b/spec/factories/invites.rb
@@ -1,17 +1,17 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :invite do
     email { FFaker::Internet.email }
-    sender_id 1
-    receiver_id 2
-    token "token1234"
+    sender_id { 1 }
+    receiver_id { 2 }
+    token { 'token1234' }
     list
 
     factory :invalid_invite do
-      email nil
+      email { nil }
     end
 
     factory :invalid_email_invite do
-      email "test.com"
+      email { 'test.com' }
     end
   end
 

--- a/spec/factories/listings.rb
+++ b/spec/factories/listings.rb
@@ -1,12 +1,12 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :listing do
     list
     movie
     user
-    priority 3
+    priority { 3 }
 
     factory :invalid_listing do
-      movie nil
+      movie { nil }
     end
   end
 

--- a/spec/factories/lists.rb
+++ b/spec/factories/lists.rb
@@ -1,13 +1,13 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :list do
-    owner_id 1
+    owner_id { 1 }
     sequence(:name) { |n| "list name#{n}" }
-    is_main false
-    is_public false
+    is_main { false }
+    is_public { false }
     description { FFaker::HipsterIpsum.phrase }
 
     factory :invalid_list do
-      name nil
+      name { nil }
     end
 
     factory :list_with_too_long_name do

--- a/spec/factories/memberships.rb
+++ b/spec/factories/memberships.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :membership do
     list
     member

--- a/spec/factories/movies.rb
+++ b/spec/factories/movies.rb
@@ -1,20 +1,20 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :movie do
     title { FFaker::Movie.title }
     sequence(:tmdb_id) { |n| n + 10 }
     imdb_id { FFaker::Product.model }
-    backdrop_path "/lGAaaOzqw8nc14HOgSP58TWWo1y.jpg"
-    poster_path "/aZeX4XNSqa08TdMHRB1gDLO6GOi.jpg"
-    release_date "2015-12-07"
+    backdrop_path { '/lGAaaOzqw8nc14HOgSP58TWWo1y.jpg' }
+    poster_path { '/aZeX4XNSqa08TdMHRB1gDLO6GOi.jpg' }
+    release_date { '2015-12-07' }
     overview { FFaker::HipsterIpsum.paragraph }
-    trailer "h2tY82z3xXU"
-    vote_average 7.5
-    popularity 1.5
-    mpaa_rating "R"
+    trailer { 'h2tY82z3xXU' }
+    vote_average { 7.5 }
+    popularity { 1.5 }
+    mpaa_rating { 'R' }
     director { FFaker::Name.name }
 
     factory :invalid_movie do
-      tmdb_id nil
+      tmdb_id { nil }
     end
   end
 

--- a/spec/factories/ratings.rb
+++ b/spec/factories/ratings.rb
@@ -1,11 +1,11 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :rating do
     user
     movie
-    value 6
+    value { 6 }
 
     factory :invalid_rating do
-      value nil
+      value { nil }
     end
   end
 

--- a/spec/factories/reviews.rb
+++ b/spec/factories/reviews.rb
@@ -1,11 +1,11 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :review do
     user
     movie
     body { FFaker::HipsterIpsum.sentence }
 
     factory :invalid_review do
-      body nil
+      body { nil }
     end
   end
 

--- a/spec/factories/screenings.rb
+++ b/spec/factories/screenings.rb
@@ -1,13 +1,13 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :screening do
     user
     movie
-    date_watched "2015-12-14"
-    location_watched "in a theater"
+    date_watched { '2015-12-14' }
+    location_watched { 'in a theater' }
     notes { FFaker::HipsterIpsum.sentence }
 
     factory :invalid_screening do
-      movie nil
+      movie { nil }
     end
   end
 

--- a/spec/factories/taggings.rb
+++ b/spec/factories/taggings.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :tagging do
     tag
     movie

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,9 +1,9 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :tag do
     sequence(:name) { |n| "tag name#{n}" }
 
     factory :invalid_tag do
-      name nil
+      name { nil }
     end
 
     factory :tag_too_long do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,14 +1,14 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user, :aliases => [:member, :owner] do
     email { FFaker::Internet.email }
-    password 'password'
-    password_confirmation 'password'
+    password { 'password' }
+    password_confirmation { 'password' }
     sequence(:username) { |n| "user_name#{n}" }
     # username { FFaker::Internet.user_name }
-    confirmed_at Time.now
+    confirmed_at { Time.now }
 
     factory :invalid_user do
-      email nil
+      email { nil }
     end
   end
 

--- a/spec/features/invites_feature_spec.rb
+++ b/spec/features/invites_feature_spec.rb
@@ -4,11 +4,11 @@ RSpec.feature "Invites feature spec", :type => :feature do
 
   feature "User can send an invite to another user" do
 
-    let(:user1) { FactoryGirl.create(:user) }
-    let(:user2) { FactoryGirl.create(:user) }
+    let(:user1) { FactoryBot.create(:user) }
+    let(:user2) { FactoryBot.create(:user) }
     let(:username) { FFaker::Internet.user_name }
     let(:receiver_email) { FFaker::Internet.email }
-    let(:list) { FactoryGirl.create(:list, owner_id: user1.id) }
+    let(:list) { FactoryBot.create(:list, owner_id: user1.id) }
 
 
     scenario "users can send invite" do

--- a/spec/features/lists_feature_spec.rb
+++ b/spec/features/lists_feature_spec.rb
@@ -4,27 +4,27 @@ RSpec.feature "Lists feature spec", :type => :feature do
 
   feature "List views" do
 
-    let(:user) { FactoryGirl.create(:user) }
+    let(:user) { FactoryBot.create(:user) }
     let(:email) { FFaker::Internet.email }
     let(:username) { FFaker::Internet.user_name }
-    let(:user2) { FactoryGirl.create(:user) }
-    let(:movie) { FactoryGirl.create(:movie) }
-    let(:movie2) { FactoryGirl.create(:movie) }
-    let(:fargo) { FactoryGirl.create(:movie, title: "Fargo", runtime: 90,
+    let(:user2) { FactoryBot.create(:user) }
+    let(:movie) { FactoryBot.create(:movie) }
+    let(:movie2) { FactoryBot.create(:movie) }
+    let(:fargo) { FactoryBot.create(:movie, title: "Fargo", runtime: 90,
       vote_average: 8, release_date: Date.today - 8000) }
-    let(:no_country) { FactoryGirl.create(:movie, title: "No Country for Old Men", runtime: 100,
+    let(:no_country) { FactoryBot.create(:movie, title: "No Country for Old Men", runtime: 100,
       vote_average: 9, release_date: Date.today - 6000) }
-    let(:fargo_listing) { FactoryGirl.create(:listing, list_id: list.id, movie_id: fargo.id) }
-    let(:no_country_listing) { FactoryGirl.create(:listing, list_id: list.id, movie_id: no_country.id) }
-    let(:list) { FactoryGirl.create(:list, owner_id: user.id) }
-    let(:list1) { FactoryGirl.create(:list, name: "my queue", owner_id: user.id) }
-    let(:list2) { FactoryGirl.create(:list, owner_id: user2.id) }
-    let(:list3) { FactoryGirl.create(:list, owner_id: user.id) }
-    let(:public_list) { FactoryGirl.create(:list, :owner => user, :is_public => true) }
-    let(:listing) { FactoryGirl.create(:listing, list_id: list.id, movie_id: movie.id) }
-    let(:listing2) { FactoryGirl.create(:listing, list_id: list2.id, movie_id: movie.id) }
-    let(:listing3) { FactoryGirl.create(:listing, list_id: list3.id, movie_id: movie.id) }
-    let(:public_listing) { FactoryGirl.create(:listing, list_id: public_list.id, movie_id: movie2.id) }
+    let(:fargo_listing) { FactoryBot.create(:listing, list_id: list.id, movie_id: fargo.id) }
+    let(:no_country_listing) { FactoryBot.create(:listing, list_id: list.id, movie_id: no_country.id) }
+    let(:list) { FactoryBot.create(:list, owner_id: user.id) }
+    let(:list1) { FactoryBot.create(:list, name: "my queue", owner_id: user.id) }
+    let(:list2) { FactoryBot.create(:list, owner_id: user2.id) }
+    let(:list3) { FactoryBot.create(:list, owner_id: user.id) }
+    let(:public_list) { FactoryBot.create(:list, :owner => user, :is_public => true) }
+    let(:listing) { FactoryBot.create(:listing, list_id: list.id, movie_id: movie.id) }
+    let(:listing2) { FactoryBot.create(:listing, list_id: list2.id, movie_id: movie.id) }
+    let(:listing3) { FactoryBot.create(:listing, list_id: list3.id, movie_id: movie.id) }
+    let(:public_listing) { FactoryBot.create(:listing, list_id: public_list.id, movie_id: movie2.id) }
     let(:list_name) { FFaker::HipsterIpsum.words(1).join(' ') }
     let(:list_description) { FFaker::HipsterIpsum.phrase }
 
@@ -66,7 +66,7 @@ RSpec.feature "Lists feature spec", :type => :feature do
       scenario "listings are destroyed when list is deleted" do
         sign_in_user(user)
         list
-        FactoryGirl.create(:listing, list_id: list.id, movie_id: movie.id)
+        FactoryBot.create(:listing, list_id: list.id, movie_id: movie.id)
         expect(user.movies).to include(movie)
         click_link "my_lists_nav_link"
         click_link "edit_list_link_list_index"
@@ -77,7 +77,7 @@ RSpec.feature "Lists feature spec", :type => :feature do
       scenario "memberships are destroyed when list is deleted" do
         sign_in_user(user)
         list
-        FactoryGirl.create(:membership, list_id: list.id, member_id: user2.id)
+        FactoryBot.create(:membership, list_id: list.id, member_id: user2.id)
         expect(user2.member_lists).to include(list)
         click_link "my_lists_nav_link"
         click_link "edit_list_link_list_index"
@@ -130,10 +130,10 @@ RSpec.feature "Lists feature spec", :type => :feature do
     describe "list show page paginates movies" do
       scenario "list show page paginates movies" do
         sign_in_user(user)
-        30.times { FactoryGirl.create(:movie) }
+        30.times { FactoryBot.create(:movie) }
         counter = Movie.first.id
         30.times do
-          FactoryGirl.create(:listing, list_id: list.id, movie_id: Movie.find(counter).id)
+          FactoryBot.create(:listing, list_id: list.id, movie_id: Movie.find(counter).id)
           counter += 1
         end
         visit user_list_path(user, list)
@@ -408,10 +408,10 @@ RSpec.feature "Lists feature spec", :type => :feature do
       describe "public show page pagination" do
         it "should paginate the movies on a public list" do
           sign_in_user(user)
-          30.times { FactoryGirl.create(:movie) }
+          30.times { FactoryBot.create(:movie) }
           counter = (Movie.first.id + 1)
           30.times do
-            FactoryGirl.create(:listing, list_id: public_list.id, movie_id: Movie.find(counter).id, user_id: user.id)
+            FactoryBot.create(:listing, list_id: public_list.id, movie_id: Movie.find(counter).id, user_id: user.id)
             counter += 1
           end
           click_link "sign_out_nav_link"
@@ -428,7 +428,7 @@ RSpec.feature "Lists feature spec", :type => :feature do
       describe "public list page pagination" do
         it "should paginate the lists on the all lists page" do
           sign_in_user(user)
-          30.times { FactoryGirl.create(:list, is_public: true, owner: user) }
+          30.times { FactoryBot.create(:list, is_public: true, owner: user) }
           click_link "sign_out_nav_link"
           sign_in_user(user2)
           click_link "public_lists_nav_link"

--- a/spec/features/memberships_feature_spec.rb
+++ b/spec/features/memberships_feature_spec.rb
@@ -4,18 +4,18 @@ RSpec.feature "Memberships feature spec", :type => :feature do
 
   feature "User can access lists and movies they're members of" do
 
-    let(:user1) { FactoryGirl.create(:user) }
-    let(:user2) { FactoryGirl.create(:user) }
-    let(:user3) { FactoryGirl.create(:user) }
-    let(:movie1) { FactoryGirl.create(:movie) }
-    let(:list) { FactoryGirl.create(:list, owner_id: user1.id) }
-    let(:listing1) { FactoryGirl.create(:listing, list_id: list.id, movie_id: movie1.id) }
-    let(:membership1) { FactoryGirl.create(:membership, list_id: list.id, member_id: user1.id) }
-    let(:membership2) { FactoryGirl.create(:membership, list_id: list.id, member_id: user2.id) }
-    let(:tag1) { FactoryGirl.create(:tag) }
-    let(:tag2) { FactoryGirl.create(:tag, name: SecureRandom.urlsafe_base64(5)) }
-    let(:tagging1) { FactoryGirl.create(:tagging, tag_id: tag1.id, movie_id: movie1.id, user_id: user1.id) }
-    let(:tagging2) { FactoryGirl.create(:tagging, tag_id: tag2.id, movie_id: movie1.id, user_id: user3.id) }
+    let(:user1) { FactoryBot.create(:user) }
+    let(:user2) { FactoryBot.create(:user) }
+    let(:user3) { FactoryBot.create(:user) }
+    let(:movie1) { FactoryBot.create(:movie) }
+    let(:list) { FactoryBot.create(:list, owner_id: user1.id) }
+    let(:listing1) { FactoryBot.create(:listing, list_id: list.id, movie_id: movie1.id) }
+    let(:membership1) { FactoryBot.create(:membership, list_id: list.id, member_id: user1.id) }
+    let(:membership2) { FactoryBot.create(:membership, list_id: list.id, member_id: user2.id) }
+    let(:tag1) { FactoryBot.create(:tag) }
+    let(:tag2) { FactoryBot.create(:tag, name: SecureRandom.urlsafe_base64(5)) }
+    let(:tagging1) { FactoryBot.create(:tagging, tag_id: tag1.id, movie_id: movie1.id, user_id: user1.id) }
+    let(:tagging2) { FactoryBot.create(:tagging, tag_id: tag2.id, movie_id: movie1.id, user_id: user3.id) }
 
 
     context "without JS" do

--- a/spec/features/pages_feature_spec.rb
+++ b/spec/features/pages_feature_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature "Pages feature spec", :type => :feature do
 
-  let(:user) { FactoryGirl.create(:user) }
+  let(:user) { FactoryBot.create(:user) }
 
   describe "search by title" do
 

--- a/spec/features/tmdb_feature_spec.rb
+++ b/spec/features/tmdb_feature_spec.rb
@@ -4,10 +4,10 @@ RSpec.feature "TMDB feature spec", :type => :feature do
 
   feature "User can perform various searches using the TMDB api" do
 
-    let(:user) { FactoryGirl.create(:user) }
+    let(:user) { FactoryBot.create(:user) }
     let(:email) { FFaker::Internet.email }
     let(:username) { FFaker::Internet.user_name }
-    let(:list) { FactoryGirl.create(:list, name: "my queue", owner_id: user.id) }
+    let(:list) { FactoryBot.create(:list, name: "my queue", owner_id: user.id) }
 
     describe "search by title" do
 

--- a/spec/features/users_feature_spec.rb
+++ b/spec/features/users_feature_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Users feature spec", :type => :feature do
   feature "Users can sign up, sign in, log out, have a list, and visit profile" do
     let(:email) { FFaker::Internet.email }
     let(:username) { FFaker::Internet.user_name }
-    let(:existing_user) { FactoryGirl.create(:user, password: "password") }
+    let(:existing_user) { FactoryBot.create(:user, password: "password") }
 
     scenario "user can successfully sign up" do
       sign_up_with(email, username, "password")

--- a/spec/mailers/existing_invite_mailer_spec.rb
+++ b/spec/mailers/existing_invite_mailer_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe ExistingInviteMailer, type: :mailer do
-let(:user) { FactoryGirl.create(:user) }
-let(:list) { FactoryGirl.create(:list, owner_id: user.id) }
-let(:invite) { FactoryGirl.create(:invite, sender_id: user.id, list_id: list.id) }
+let(:user) { FactoryBot.create(:user) }
+let(:list) { FactoryBot.create(:list, owner_id: user.id) }
+let(:invite) { FactoryBot.create(:invite, sender_id: user.id, list_id: list.id) }
 let(:mail) { ExistingInviteMailer.existing_invite_mailer(invite) }
 
   describe "invite mailer" do

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe InviteMailer, type: :mailer do
 
-let(:user) { FactoryGirl.create(:user) }
-let(:invite) { FactoryGirl.create(:invite, sender_id: user.id) }
+let(:user) { FactoryBot.create(:user) }
+let(:invite) { FactoryBot.create(:invite, sender_id: user.id) }
 let(:mail) { InviteMailer.new_invite_mailer(invite) }
 
   describe "invite mailer" do

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Invite, type: :model do
-  let(:invite) { FactoryGirl.build(:invite) }
-  let(:invalid_invite) { FactoryGirl.build(:invalid_invite) }
-  let(:invalid_email_invite) { FactoryGirl.build(:invalid_email_invite) }
+  let(:invite) { FactoryBot.build(:invite) }
+  let(:invalid_invite) { FactoryBot.build(:invalid_invite) }
+  let(:invalid_email_invite) { FactoryBot.build(:invalid_email_invite) }
 
   context "with a valid factory" do
 

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe List, type: :model do
-  let(:list) { FactoryGirl.build(:list) }
-  let(:invalid_list) { FactoryGirl.build(:invalid_list) }
-  let(:list_with_too_long_name) { FactoryGirl.build(:list_with_too_long_name) }
+  let(:list) { FactoryBot.build(:list) }
+  let(:invalid_list) { FactoryBot.build(:invalid_list) }
+  let(:list_with_too_long_name) { FactoryBot.build(:list_with_too_long_name) }
 
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name).scoped_to(:owner_id) }

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Listing, type: :model do
-  let(:listing) { FactoryGirl.build(:listing) }
-  let(:listing1) { FactoryGirl.create(:listing) }
-  let(:invalid_listing) { FactoryGirl.build(:invalid_listing) }
+  let(:listing) { FactoryBot.build(:listing) }
+  let(:listing1) { FactoryBot.create(:listing) }
+  let(:invalid_listing) { FactoryBot.build(:invalid_listing) }
 
   it { is_expected.to validate_presence_of(:list) }
   it { is_expected.to validate_presence_of(:movie) }

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Membership, type: :model do
-  let(:membership) { FactoryGirl.create(:membership) }
+  let(:membership) { FactoryBot.create(:membership) }
 
   context "with a valid factory" do
     it "has a valid factory" do

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Rating, type: :model do
-  let(:user) { FactoryGirl.create(:user) }
-  let(:movie) { FactoryGirl.create(:movie) }
-  let(:rating) { FactoryGirl.build(:rating) }
-  let(:rating2) { FactoryGirl.create(:rating, user_id: user.id, movie_id: movie.id ) }
-  let(:rating3) { FactoryGirl.build(:rating, user_id: user.id, movie_id: movie.id) }
-  let(:invalid_rating) { FactoryGirl.build(:invalid_rating) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:movie) { FactoryBot.create(:movie) }
+  let(:rating) { FactoryBot.build(:rating) }
+  let(:rating2) { FactoryBot.create(:rating, user_id: user.id, movie_id: movie.id ) }
+  let(:rating3) { FactoryBot.build(:rating, user_id: user.id, movie_id: movie.id) }
+  let(:invalid_rating) { FactoryBot.build(:invalid_rating) }
 
   it { is_expected.to validate_presence_of(:value) }
   it { is_expected.to validate_presence_of(:user_id) }

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Review, type: :model do
-  let(:user) { FactoryGirl.create(:user) }
-  let(:movie) { FactoryGirl.create(:movie) }
-  let(:review) { FactoryGirl.build(:review) }
-  let(:review2) { FactoryGirl.create(:review, user_id: user.id, movie_id: movie.id) }
-  let(:review3) { FactoryGirl.build(:review, user_id: user.id, movie_id: movie.id) }
-  let(:invalid_review) { FactoryGirl.build(:invalid_review) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:movie) { FactoryBot.create(:movie) }
+  let(:review) { FactoryBot.build(:review) }
+  let(:review2) { FactoryBot.create(:review, user_id: user.id, movie_id: movie.id) }
+  let(:review3) { FactoryBot.build(:review, user_id: user.id, movie_id: movie.id) }
+  let(:invalid_review) { FactoryBot.build(:invalid_review) }
 
   it { is_expected.to validate_presence_of(:body) }
 

--- a/spec/models/screening_spec.rb
+++ b/spec/models/screening_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Screening, type: :model do
-  let(:screening) { FactoryGirl.build(:screening) }
-  let(:invalid_screening) { FactoryGirl.build(:invalid_screening) }
+  let(:screening) { FactoryBot.build(:screening) }
+  let(:invalid_screening) { FactoryBot.build(:invalid_screening) }
 
   it { is_expected.to validate_presence_of(:user) }
   it { is_expected.to validate_presence_of(:movie) }

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Tag, type: :model do
-  let(:tag) { FactoryGirl.build(:tag) }
-  let(:invalid_tag) { FactoryGirl.build(:invalid_tag) }
-  let(:tag_too_long) { FactoryGirl.build(:tag_too_long) }
+  let(:tag) { FactoryBot.build(:tag) }
+  let(:invalid_tag) { FactoryBot.build(:invalid_tag) }
+  let(:tag_too_long) { FactoryBot.build(:tag_too_long) }
 
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name) }

--- a/spec/models/tagging_spec.rb
+++ b/spec/models/tagging_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Tagging, type: :model do
-  let(:tagging) { FactoryGirl.create(:tagging) }
+  let(:tagging) { FactoryBot.create(:tagging) }
 
   context "with a valid factory" do
     it "has a valid factory" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  let(:user) { FactoryGirl.create(:user) }
-  let(:invalid_user) { FactoryGirl.build(:invalid_user) }
-  let(:list) { FactoryGirl.create(:list, owner_id: user.id) }
-  let(:list2) { FactoryGirl.create(:list, owner_id: user.id) }
-  let(:movie) { FactoryGirl.create(:movie) }
-  let(:movie2) { FactoryGirl.create(:movie) }
-  let(:listing) { FactoryGirl.create(:listing, list_id: list.id, user_id: user.id, movie_id: movie.id ) }
-  let(:listing2) { FactoryGirl.create(:listing, list_id: list2.id, user_id: user.id, movie_id: movie2.id ) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:invalid_user) { FactoryBot.build(:invalid_user) }
+  let(:list) { FactoryBot.create(:list, owner_id: user.id) }
+  let(:list2) { FactoryBot.create(:list, owner_id: user.id) }
+  let(:movie) { FactoryBot.create(:movie) }
+  let(:movie2) { FactoryBot.create(:movie) }
+  let(:listing) { FactoryBot.create(:listing, list_id: list.id, user_id: user.id, movie_id: movie.id ) }
+  let(:listing2) { FactoryBot.create(:listing, list_id: list2.id, user_id: user.id, movie_id: movie2.id ) }
 
   it { is_expected.to validate_uniqueness_of(:username) }
   it { is_expected.to validate_presence_of(:username) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,15 +2,16 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+
 
 # Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 require 'coveralls'
 Coveralls.wear!('rails')
 require 'devise'
-require "shoulda/matchers"
+require 'shoulda/matchers'
 require 'support/controller_helpers'
 require 'support/feature_helpers'
 require 'support/mailer_helpers'
@@ -45,9 +46,7 @@ RSpec.configure do |config|
   config.include MailerHelpers
   config.include WaitForAjax, type: :feature
   config.before(:each) { reset_mailer }
-  config.include FactoryGirl::Syntax::Methods
-
-
+  config.include FactoryBot::Syntax::Methods
 
   config.use_transactional_fixtures = false
 


### PR DESCRIPTION
This branch addresses issue #139 by replacing the `factory_girl` gem with `factory_bot`. Changes include:

- Gemfile, change gem
- rails_helper, change name of module in config
- name change in all Factory files
- all spec files change `let` statements: `  let(:user) { FactoryBot.create(:user) }`
- use of `rubocop-rspec` gem to bulk-convert static factory attributes to blocks. ex: `name 'zorro'` to `name { 'zorro' }`
- addition of `.rubocop.yml` file to enable bulk conversion and set us up for using RuboCop in the future

Note: all spec files except `features` are passing.