### PR TITLE
Temporarily excludes feature specs from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ before_script:
   - sh -e /etc/init.d/xvfb start
 script:
   - bundle exec rake db:setup
-  - bundle exec rspec
+  - bundle exec rspec --exclude-pattern "**/features/*_spec.rb"


### PR DESCRIPTION
This is a small change to the `.travis.yml` file that can be undone when the feature specs are no longer flickering. I've made note of this change and how to reverse it in issue https://github.com/mikevallano/tmdb-moviequeue/issues/94 about front end specs 

```
# was: runs all the tests
  - bundle exec rspec

# changed to: excludes feature specs
  - bundle exec rspec --exclude-pattern "**/features/*_spec.rb"
```
