### PR TITLE
add link for Lists page in the navbar

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -20,7 +20,6 @@
           <ul class="dropdown-menu">
             <li><%= link_to 'Sign Out', destroy_user_session_path, :method => :delete, id: "sign_out_nav_link" %></li>
             <li><%= link_to 'Profile Settings', user_path(current_user), id: "profile_nav_link" %></li>
-            <li><%= link_to 'Manage My Lists', user_lists_path(current_user), id: "my_lists_nav_link" %></li>
           </ul><!-- dropdown items -->
         </li><!-- dropdown button -->
       </ul><!-- nav navbar-nav navbar-right -->
@@ -40,6 +39,7 @@
           <ul class="dropdown-menu">
             <li><%= link_to 'My Movies', movies_path, id: "my_movies_nav_link" %></li>
             <li><%= link_to 'Public Lists', public_lists_path, id: "public_lists_nav_link" %></li>
+            <li><%= link_to 'Manage My Lists', user_lists_path(current_user), id: "my_lists_nav_link" %></li>
             <li role="separator" class="divider"></li>
             <% current_user.all_lists_by_name.each do |list| %>
               <li><%= link_to "#{list.name}", user_list_path(list.owner, list) %></li>

--- a/spec/vcr_cassettes/tmdb_actor_search.yml
+++ b/spec/vcr_cassettes/tmdb_actor_search.yml
@@ -1099,4 +1099,50 @@ http_interactions:
         process finds himself exploring his own sense of identity.","release_date":"1991-05-28","genre_ids":[18,80],"id":22828,"original_title":"Homicide","original_language":"en","title":"Homicide","backdrop_path":"\/6zt8sn4lmj7j61limKexyKGEAPY.jpg","popularity":1.116112,"vote_count":6,"video":false,"vote_average":5}],"total_results":88,"total_pages":5}'
     http_version: 
   recorded_at: Sun, 21 Aug 2016 17:45:18 GMT
+- request:
+    method: get
+    uri: https://api.themoviedb.org/3/search/person?api_key=&query=William%20H.%20Macy
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - ETag, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Sun, 10 Mar 2019 21:35:30 GMT
+      Etag:
+      - ec8956637a99787bd197eacd77acce5e
+      Server:
+      - openresty
+      X-Ratelimit-Limit:
+      - '40'
+      X-Ratelimit-Remaining:
+      - '38'
+      X-Ratelimit-Reset:
+      - '1552253740'
+      Content-Length:
+      - '102'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status_code":7,"status_message":"Invalid API key: You must be granted
+        a valid key.","success":false}'
+    http_version: 
+  recorded_at: Sun, 10 Mar 2019 21:35:31 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/tmdb_bad_actor_search.yml
+++ b/spec/vcr_cassettes/tmdb_bad_actor_search.yml
@@ -39,4 +39,50 @@ http_interactions:
       string: '{"errors":["query must be provided"]}'
     http_version: 
   recorded_at: Wed, 24 Feb 2016 16:47:40 GMT
+- request:
+    method: get
+    uri: https://api.themoviedb.org/3/search/person?api_key=&query=&sjhskjhdf*s7
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - ETag, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Sun, 10 Mar 2019 21:35:31 GMT
+      Etag:
+      - ec8956637a99787bd197eacd77acce5e
+      Server:
+      - openresty
+      X-Ratelimit-Limit:
+      - '40'
+      X-Ratelimit-Remaining:
+      - '37'
+      X-Ratelimit-Reset:
+      - '1552253740'
+      Content-Length:
+      - '102'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status_code":7,"status_message":"Invalid API key: You must be granted
+        a valid key.","success":false}'
+    http_version: 
+  recorded_at: Sun, 10 Mar 2019 21:35:31 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/tmdb_bad_two_actor_search.yml
+++ b/spec/vcr_cassettes/tmdb_bad_two_actor_search.yml
@@ -39,4 +39,50 @@ http_interactions:
       string: '{"errors":["query must be provided"]}'
     http_version: 
   recorded_at: Wed, 24 Feb 2016 16:47:40 GMT
+- request:
+    method: get
+    uri: https://api.themoviedb.org/3/search/person?*&%5E&api_key=&query=
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - ETag, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Sun, 10 Mar 2019 21:35:32 GMT
+      Etag:
+      - ec8956637a99787bd197eacd77acce5e
+      Server:
+      - openresty
+      X-Ratelimit-Limit:
+      - '40'
+      X-Ratelimit-Remaining:
+      - '36'
+      X-Ratelimit-Reset:
+      - '1552253740'
+      Content-Length:
+      - '102'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status_code":7,"status_message":"Invalid API key: You must be granted
+        a valid key.","success":false}'
+    http_version: 
+  recorded_at: Sun, 10 Mar 2019 21:35:32 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
Resolves issue #151 

As it turns out, we _did_ have a link to this page. It was located in another part of the navbar and we never looked there. We decided that its location was unintuitive and moved it under the `My Lists`  nav heading.