### PR TITLE
159: Fix travis: Update postgres version. Move xvfb to services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ rvm:
  - 2.2.2
 services:
  - postgresql
+ - xvfb
 addons:
- postgresql: "9.3"
+ postgresql: "9.6"
  code_climate:
   repo_token: ENV["code_climate_repo_token"]
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 script:
   - bundle exec rake db:setup
   - bundle exec rspec --exclude-pattern "**/features/*_spec.rb"


### PR DESCRIPTION
- Updated `postgres` version to 9.6, which is what I'm running locally. I'm not sure _why_ that fixed it, but perhaps Travis doesn't support 9.3 anymore 🤷‍♂ 
- Moved `xvfb` to services. After getting past the db error, I googled the next error message and found the reason for the failure and how to fix: https://benlimmer.com/2019/01/14/travis-ci-xvfb/.