### PR TITLE
183 Make screenings#index better on mobile

### DIFF
--- a/app/views/screenings/_form.html.erb
+++ b/app/views/screenings/_form.html.erb
@@ -18,7 +18,7 @@
     <%= f.date_field :date_watched %>
   </div>
   <div class="field">
-    <%= f.label :location_watched %><br>
+    <%= f.label :location_watched, "Location Watched"" %><br>
     <%= f.text_field :location_watched %>
   </div>
   <div class="field">

--- a/app/views/screenings/edit.html.erb
+++ b/app/views/screenings/edit.html.erb
@@ -1,11 +1,15 @@
 <% content_for(:title, "Editing") %>
 
-<h1>Edit Your Screening</h1>
+<p class="button-main pull-right">
+  <%= link_to 'Back', movie_screenings_path(@movie) %>
+</p>
+
+<h1>Edit</h1>
 <h2>Your <%= @screening.date_watched.stamp("12-31-2016") %> Screening of <%= @movie.title %></h2>
 
 <%= render 'form' %>
 
+<hr>
 <p class="button-main">
-  <%= link_to 'Back To Screenings', movie_screenings_path(@movie) %>
-  <%= link_to 'Back To ' + @movie.title, movie_path(@movie) %>
+  <%= link_to 'Delete', movie_screening_path(@movie, @screening), method: :delete, data: { confirm: 'Are you sure you want to delete this screening? This action cannot be undone.' } %>
 </p>

--- a/app/views/screenings/index.html.erb
+++ b/app/views/screenings/index.html.erb
@@ -3,23 +3,19 @@
 <h1>Screenings for <%= link_to "#{@movie.title}", movie_path(@movie) %></h1>
 
 <table class="table">
-  <thead>
-    <tr>
-      <th>Date Watched</th>
-      <th>Location Watched</th>
-      <th>Notes</th>
-      <th colspan="3">Manage Screenings</th>
-    </tr>
-  </thead>
-
   <tbody>
     <% @screenings.order("date_watched DESC").each do |screening| %>
       <tr>
         <td><%= screening.date_watched.stamp("1/2/2001") %></td>
-        <td><%= screening.location_watched %></td>
-        <td><%= screening.notes %></td>
-        <td><%= link_to 'Edit', edit_movie_screening_path(@movie, screening) %></td>
-        <td><%= link_to 'Delete', movie_screening_path(@movie, screening), method: :delete, data: { confirm: 'Are you sure you want to delete this screening? This action cannot be undone.' } %></td>
+        <td>
+          <p>
+            <strong><%= screening.location_watched %></strong><br />
+            <%= screening.notes %>
+          </p>
+        </td>
+        <td>
+          <%= link_to 'Edit', edit_movie_screening_path(@movie, screening) %>
+        </td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
## Related Issues & PRs
Closes #183

## Problems Solved
The screenings index is a table and it renders poorly on mobile. Now it looks better.
* Let content span more horizontal space by stacking it
* Removed table headers because they're unnecessary
* Moved "delete" button to edit page.
* Shortened the `h1` text for brevity on edit page


## Screenshots
### Before:
<img width="345" alt="Screenshot 2020-02-04 08 35 10" src="https://user-images.githubusercontent.com/8680712/73749381-48460100-4729-11ea-80d9-60fc5dc3e137.png">

### After:
<img width="346" alt="Screenshot 2020-02-04 08 27 39" src="https://user-images.githubusercontent.com/8680712/73749174-d372c700-4728-11ea-9655-f17282ed8563.png">


## Things Learned
Ooooh we have some css badness going on. When I tried to make the form fields use bootstrap's `form-control` class, things went wild. I abandoned ship as it was not a priority part of this feature change.  
