### PR TITLE
Fix syntax error

### DIFF
--- a/app/views/screenings/_form.html.erb
+++ b/app/views/screenings/_form.html.erb
@@ -18,7 +18,7 @@
     <%= f.date_field :date_watched %>
   </div>
   <div class="field">
-    <%= f.label :location_watched, "Location Watched"" %><br>
+    <%= f.label :location_watched, "Location Watched" %><br>
     <%= f.text_field :location_watched %>
   </div>
   <div class="field">


### PR DESCRIPTION
## Problems Solved
> The screenings form page was not loading, which caused a 500 error.

## Things Learned
> If we had a functional set of front-end tests, that would have caught this bug. More importantly, checking it in the browser locally would have caught it. I missed checking it one last time before shipping it and this is what happened. #distracted
