### PR TITLE
WIP this fixes the broken link on mobile

### DIFF
--- a/app/views/movies/_movie_partial_loop.html.erb
+++ b/app/views/movies/_movie_partial_loop.html.erb
@@ -12,7 +12,8 @@
         </p>
 
         <p id="modal-trigger-mobile">
-          <%= link_to image_for(movie), movie_path(movie) %>
+          <%#= link_to image_for(movie), movie_path(movie) %>
+          <%= link_to image_for(movie), movie_more_path(tmdb_id: "#{movie.tmdb_id}") %>
         </p>
 
         <div id="movies_partial_<%= "#{movie.tmdb_id}" %>"></div>


### PR DESCRIPTION
## Related Issues & PRs
> Closes #180

## Problems Solved
After I removed the modal from the portrait mobile view (via media query), when i clicked on a movie cover, i got a 404 when trying to go to the show page. I rotated my phone to landscape where the modal could still work, clicked on the link to show and it worked. 

My guess was that we were missing some sort of call to the API to build that info before we get to the show page. To work around that, I used a route that let me pass in the tmdb id:
```ruby
link_to image_for(movie), movie_path(movie)
```

With this workaround, I'm not sure we're using the `movies/show` page anymore. 🤷‍♀ This may not be the most sound approach.

## Screenshots
Before
![before](https://user-images.githubusercontent.com/8680712/75611022-319e8a00-5adc-11ea-8550-adc5e9e54f9d.gif)


After
![after](https://user-images.githubusercontent.com/8680712/75611025-38c59800-5adc-11ea-8106-9beb254d7ef5.gif)

