### PR TITLE
190 add default location to user

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,11 @@
 ## Related Issues & PRs
-> Closes #X
+Closes #X
 
 ## Problems Solved
->
+*
 
 ## Screenshots
 [screenshots here]
 
 ## Things Learned
->
+*

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,6 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :email, :password, :password_confirmation, :remember_me])
     devise_parameter_sanitizer.permit(:sign_in, keys: [:login, :username, :email, :password, :remember_me])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:username, :email, :password, :password_confirmation, :current_password])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:username, :email, :default_location, :password, :password_confirmation, :current_password])
   end
 end

--- a/app/controllers/screenings_controller.rb
+++ b/app/controllers/screenings_controller.rb
@@ -14,7 +14,7 @@ class ScreeningsController < ApplicationController
 
   def new
     default_params = {
-      date_watched: Time.zone.today,
+      date_watched: Date.current,
       location_watched: current_user.default_location
     }
     @screening = @movie.screenings

--- a/app/controllers/screenings_controller.rb
+++ b/app/controllers/screenings_controller.rb
@@ -13,7 +13,13 @@ class ScreeningsController < ApplicationController
   end
 
   def new
-    @screening = @movie.screenings.by_user(current_user).new
+    default_params = {
+      date_watched: Time.zone.today,
+      location_watched: current_user.default_location
+    }
+    @screening = @movie.screenings
+                       .by_user(current_user)
+                       .new(default_params)
   end
 
   def edit

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -13,6 +13,11 @@
     <%= f.text_field :username %>
   </div>
 
+  <div class="field">
+   <%= f.label :default_location %><br />
+   <%= f.text_field :default_location %>
+ </div>
+
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -14,7 +14,7 @@
   </div>
 
   <div class="field">
-   <%= f.label :default_location %><br />
+   <%= f.label :default_location, 'Default Location for screenings (where you watched the movie)' %><br />
    <%= f.text_field :default_location %>
  </div>
 

--- a/app/views/movies/_movie_screening.html.erb
+++ b/app/views/movies/_movie_screening.html.erb
@@ -9,7 +9,7 @@
 <% else %> <!-- #if movie has been seen -->
 
   <p class="sidebar-button">
-    <%= link_to '<i class="fa fa-square-o"></i> Mark as Watched'.html_safe, screenings_path(:screening => { notes: nil }, tmdb_id: movie.tmdb_id, from: "movies_index", page: params[:page]), :method => :post, id: "mark_watched_link_movies_partial", remote: true %>
+    <%= link_to '<i class="fa fa-square-o"></i> Mark as Watched'.html_safe, screenings_path(screening: { location_watched: current_user.default_location }, tmdb_id: movie.tmdb_id, from: "movies_index", page: params[:page]), :method => :post, id: "mark_watched_link_movies_partial", remote: true %>
     </p>
 
 <% end %> <!-- #if movie has been seen -->

--- a/app/views/movies/_movie_screening.html.erb
+++ b/app/views/movies/_movie_screening.html.erb
@@ -1,17 +1,20 @@
 <div id="movie_seen_<%= "#{movie.tmdb_id}" %>">
 
 <% if current_user.watched_movies.include?(movie) %> <!-- #if movie has been seen -->
-
   <p class="sidebar-button">
     <%= link_to '<i class="fa fa-check-square-o"></i> Watched. Add/View Screenings'.html_safe, movie_screenings_path(movie), id: "add_screening_link_movies_partial" %>
   </p>
-
 <% else %> <!-- #if movie has been seen -->
-
   <p class="sidebar-button">
-    <%= link_to '<i class="fa fa-square-o"></i> Mark as Watched'.html_safe, screenings_path(screening: { location_watched: current_user.default_location }, tmdb_id: movie.tmdb_id, from: "movies_index", page: params[:page]), :method => :post, id: "mark_watched_link_movies_partial", remote: true %>
-    </p>
-
+    <%= link_to '<i class="fa fa-square-o"></i> Mark as Watched'.html_safe, screenings_path(
+        screening: { location_watched: current_user.default_location },
+        tmdb_id: movie.tmdb_id,
+        from: 'movies_index',
+        page: params[:page]
+      ),
+      method: :post,
+      id: 'mark_watched_link_movies_partial',
+      remote: true %>
+  </p>
 <% end %> <!-- #if movie has been seen -->
-
 </div><!-- id= movie_seen -->

--- a/app/views/movies/_movie_show_screening.html.erb
+++ b/app/views/movies/_movie_show_screening.html.erb
@@ -5,5 +5,16 @@
   <span class="screening-link"><%= link_to "Add / Manage Screenings", movie_screenings_path(@movie), id: "add_screening_link_movies_partial" %></span>
 <% else %> <!-- #if movie has been seen -->
   <h2>You Haven't Seen this One Yet!
-  <span class="screening-link"><%= link_to "Mark as Watched", screenings_path(screening: { location_watched: current_user.default_location }, tmdb_id: @movie.tmdb_id, from: "movies_index", page: params[:page]), :method => :post, id: "mark_watched_link_movies_partial", remote: true %></span></h2>
+    <span class='screening-link'>
+      <%= link_to 'Mark as Watched', screenings_path(
+        screening: { location_watched: current_user.default_location },
+        tmdb_id: @movie.tmdb_id,
+        from: 'movies_index',
+        page: params[:page]
+      ),
+      method: :post,
+      id: 'mark_watched_link_movies_partial',
+      remote: true %>
+    </span>
+  </h2>
 <% end %> <!-- #if movie has been seen -->

--- a/app/views/movies/_movie_show_screening.html.erb
+++ b/app/views/movies/_movie_show_screening.html.erb
@@ -5,5 +5,5 @@
   <span class="screening-link"><%= link_to "Add / Manage Screenings", movie_screenings_path(@movie), id: "add_screening_link_movies_partial" %></span>
 <% else %> <!-- #if movie has been seen -->
   <h2>You Haven't Seen this One Yet!
-  <span class="screening-link"><%= link_to "Mark as Watched", screenings_path(:screening => { notes: nil }, tmdb_id: @movie.tmdb_id, from: "movies_index", page: params[:page]), :method => :post, id: "mark_watched_link_movies_partial", remote: true %></span></h2>
+  <span class="screening-link"><%= link_to "Mark as Watched", screenings_path(screening: { location_watched: current_user.default_location }, tmdb_id: @movie.tmdb_id, from: "movies_index", page: params[:page]), :method => :post, id: "mark_watched_link_movies_partial", remote: true %></span></h2>
 <% end %> <!-- #if movie has been seen -->

--- a/app/views/screenings/_form.html.erb
+++ b/app/views/screenings/_form.html.erb
@@ -18,7 +18,13 @@
     <%= f.date_field :date_watched %>
   </div>
   <div class="field">
-    <%= f.label :location_watched, "Location Watched" %><br>
+    <%= f.label :location_watched, 'Location Watched' %>
+    <span>
+      <%= link_to 'set default location',
+                  user_path(current_user),
+                  title: 'Set a default location for where you watch movies most frequently.'
+      %>
+    </span><br/>
     <%= f.text_field :location_watched %>
   </div>
   <div class="field">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,4 +5,4 @@
 <p><strong>Email:</strong> <%= current_user.email %></p>
 <p><strong>Default Screening Location:</strong> <%= current_user.default_location %></p>
 <p><strong>Password:</strong> **********</p>
-<p><%= link_to "Change your password/update info", edit_user_registration_path, id: "edit_user_link_profile_page" %></p>
+<p><%= link_to 'Change your password/update info', edit_user_registration_path, id: 'edit_user_link_profile_page' %></p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,8 @@
 <% content_for(:title, current_user.email) %>
 
 <h1>Profile page for <%= current_user.username %></h1>
-<p>Email: <%= current_user.email %></p>
+<p><strong>Username:</strong> <%= current_user.username %></p>
+<p><strong>Email:</strong> <%= current_user.email %></p>
+<p><strong>Default Screening Location:</strong> <%= current_user.default_location %></p>
+<p><strong>Password:</strong> **********</p>
 <p><%= link_to "Change your password/update info", edit_user_registration_path, id: "edit_user_link_profile_page" %></p>

--- a/db/migrate/20200411183221_add_default_location_to_user.rb
+++ b/db/migrate/20200411183221_add_default_location_to_user.rb
@@ -1,0 +1,5 @@
+class AddDefaultLocationToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :default_location, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160128204311) do
+ActiveRecord::Schema.define(version: 20200411183221) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -170,6 +170,7 @@ ActiveRecord::Schema.define(version: 20160128204311) do
     t.string   "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
+    t.string   "default_location"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree


### PR DESCRIPTION
## Related Issues & PRs
Closes #190

## Problems Solved
* A user can set  their `default_location` in their user profile and this will populate the screening location automatically for them.
* New screenings now have a default `date_watched` of today.
* The user profile page now shows default location.
* Unrelated: I updated the PR template to get rid of the block quote because we don't like that style.

## Screenshots
Profile page now has these new fields
<img width="464" alt="Screenshot 2020-04-11 17 25 53" src="https://user-images.githubusercontent.com/8680712/79056209-83791a80-7c19-11ea-8de3-f1cbcd0b75fe.png">

User registration edit form
<img width="519" alt="Screenshot 2020-04-11 17 24 04" src="https://user-images.githubusercontent.com/8680712/79056187-4e6cc800-7c19-11ea-878a-07fbc57a36d5.png">

New screening now populates the user's default location
<img width="340" alt="Screenshot 2020-04-11 17 23 54" src="https://user-images.githubusercontent.com/8680712/79056186-4dd43180-7c19-11ea-8e76-08ebf3d252f9.png">

