### PR TITLE
193 Add background color and movie name to missing image

### DIFF
--- a/app/assets/stylesheets/movies.scss
+++ b/app/assets/stylesheets/movies.scss
@@ -5,6 +5,7 @@ $index-poster-width: 125px;
 $index-poster-height: 185px;
 $responsive-poster-width: 100%;
 $responsive-poster-height: $responsive-poster-width*.48+$responsive-poster-width;
+$missing-poster-background-color: lighten($primary-background-color, 20%);
 
 /* MOVIE INDEX PAGE */
 
@@ -22,12 +23,12 @@ article.tile-cover-pic {
     width: $responsive-poster-width;
     height: $responsive-poster-height;
   } /* img */
-
+  background-color: $missing-poster-background-color;
 } /* article.tile-cover-pic */
 
 .missing-poster {
   position: relative;
-  background-color: lighten($primary-background-color, 20%);
+  background-color: $missing-poster-background-color;
   float: left;
   margin: -10px 10px 10px 0px;
   width: $index-poster-width;
@@ -66,6 +67,7 @@ article.tile-cover-pic {
 .modal {
   img {
     border: 1px solid #000;
+    background-color: $missing-poster-background-color;
   } /* img */
   h1 {
     line-height: 99%;
@@ -99,6 +101,7 @@ article.tile-cover-pic {
   .missing-poster {
     width: $index-poster-width;
     height: $index-poster-height;
+    background-color: $missing-poster-background-color;
   } /* .missing-poster */
 } /* .modal */
 
@@ -106,7 +109,6 @@ article.tile-cover-pic {
 /* MOVIE SHOW PAGE */
 
 .movie-show {
-
   a {
     color: $link-color;
 

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -2,7 +2,7 @@ module MoviesHelper
 
   def image_for(movie)
     if movie.poster_path.present?
-      image_tag("http://image.tmdb.org/t/p/w185#{movie.poster_path}")
+      image_tag("http://image.tmdb.org/t/p/w185#{movie.poster_path}", title: movie.title, alt: movie.title)
     else
       render "movies/movie_missing_poster", movie: movie
       # image_tag('placeholder.png')


### PR DESCRIPTION
## Related Issues & PRs
Relates to #193

## Problems Solved
We have a problem with the TMDB api right now. It's not showing images and we're not sure what the problem is. This PR does not fix that problem, but offers a stop-gap so that we can at least see what the movie is supposed to be and allows us to click on that movie title. This is the first step in addressing the problem. When we do resolve the problem with the TMDB api, this work will still exist behind the scenes and be ready for if/when a movie poster image source is broken in the future.

Before
<img width="500" alt="Screenshot 2020-05-10 09 11 05" src="https://user-images.githubusercontent.com/8680712/81503324-a0504e80-92a8-11ea-97ed-2dc12a4b2926.png">

After
<img width="500" alt="Screenshot 2020-05-10 10 23 53" src="https://user-images.githubusercontent.com/8680712/81503351-c544c180-92a8-11ea-91c2-56e731f8406f.png">
