### PR TITLE
193: Get updated tmdb data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'devise'
 gem 'figaro'
 gem 'friendly_id'
+gem 'httparty'
 gem 'rails_12factor', group: :production
 gem 'will_paginate'
 gem 'coveralls', '0.8.11', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,9 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (1.0.0)
+    httparty (0.18.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
@@ -146,9 +149,13 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.0512)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.12.2)
+    multi_xml (0.6.0)
     multipart-post (2.1.1)
     nenv (0.3.0)
     nio4r (2.5.2)
@@ -336,6 +343,7 @@ DEPENDENCIES
   figaro
   friendly_id
   guard-rspec
+  httparty
   jbuilder (~> 2.0)
   jquery-rails
   jquery-ui-rails

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -34,7 +34,8 @@ class TmdbController < ApplicationController
   def update_tmdb_data
     if params[:tmdb_id]
       @tmdb_id = params[:tmdb_id]
-      TmdbHandler.tmdb_handler_update_movie(@tmdb_id)
+      movie = Movie.find_by!(tmdb_id: @tmdb_id)
+      TmdbHandler.tmdb_handler_update_movie(movie)
     end
     redirect_to movie_more_path(tmdb_id: @tmdb_id)
   end

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -34,7 +34,7 @@ class TmdbController < ApplicationController
   def update_tmdb_data
     if params[:tmdb_id]
       @tmdb_id = params[:tmdb_id]
-      tmdb_handler_update_movie(@tmdb_id)
+      TmdbHandler.tmdb_handler_update_movie(@tmdb_id)
     end
     redirect_to movie_more_path(tmdb_id: @tmdb_id)
   end

--- a/lib/tasks/update_tmdb_data.rake
+++ b/lib/tasks/update_tmdb_data.rake
@@ -1,8 +1,8 @@
 # To run the rake task: rake "tmdb_data:refresh"
 # To run from console: Rake::Task["tmdb_data:refresh"].invoke
 
-TIME_FRAME = 1.week.ago
-BATCH_SIZE = 50
+TIME_FRAME = (ENV['tmdb_refresh_time_frame_days'] || 7).to_i.days.ago
+BATCH_SIZE = (ENV['tmdb_refresh_batch_size'] || 50).to_i
 
 namespace :tmdb_data do
   desc 'refresh tmdb_data'

--- a/lib/tasks/update_tmdb_data.rake
+++ b/lib/tasks/update_tmdb_data.rake
@@ -7,19 +7,18 @@ BATCH_SIZE = (ENV['tmdb_refresh_batch_size'] || 50).to_i
 namespace :tmdb_data do
   desc 'refresh tmdb_data'
   task :refresh => :environment do
-    tmdb_ids = Movie
+    movies = Movie
       .where('updated_at < ?', TIME_FRAME)
       .order(updated_at: :asc)
       .limit(BATCH_SIZE)
-      .pluck(:tmdb_id)
 
-    puts "*** Refreshing #{tmdb_ids.count} movies..."
+    puts "*** Refreshing #{movies.count} movies..."
     updated_movies = []
 
-    tmdb_ids.each do |tmdb_id|
-      TmdbHandler.tmdb_handler_update_movie(tmdb_id)
-      puts "Movie refreshed. tmdb_id: #{tmdb_id}"
-      updated_movies << tmdb_id
+    movies.each do |movie|
+      TmdbHandler.tmdb_handler_update_movie(movie)
+      puts "Movie refreshed. tmdb_id: #{movie.tmdb_id}"
+      updated_movies << movie.tmdb_id
       sleep 0.01
     end
     output = "*** Updated_movies: count: #{updated_movies.count}. tmdb_ids: #{updated_movies}"

--- a/lib/tasks/update_tmdb_data.rake
+++ b/lib/tasks/update_tmdb_data.rake
@@ -22,7 +22,11 @@ namespace :tmdb_data do
       updated_movies << tmdb_id
       sleep 0.01
     end
-
-    puts "*** Updated_movies: count: #{updated_movies.count}. tmdb_ids: #{updated_movies}"
+    output = "*** Updated_movies: count: #{updated_movies.count}. tmdb_ids: #{updated_movies}"
+    puts output
+  rescue => error
+    output = "*** Updated_movies: count: #{updated_movies.count}. tmdb_ids: #{updated_movies}"
+    puts "Not all movies uptated. #{output}"
+    raise error
   end
 end

--- a/lib/tasks/update_tmdb_data.rake
+++ b/lib/tasks/update_tmdb_data.rake
@@ -1,5 +1,5 @@
-# rake "tmdb_data:refresh"
-# from console: Rake::Task["tmdb_data:refresh"].invoke
+# To run the rake task: rake "tmdb_data:refresh"
+# To run from console: Rake::Task["tmdb_data:refresh"].invoke
 
 TIME_FRAME = 1.week.ago
 BATCH_SIZE = 50
@@ -17,14 +17,10 @@ namespace :tmdb_data do
     updated_movies = []
 
     tmdb_ids.each do |tmdb_id|
-      res = TmdbHandler.tmdb_handler_update_movie(tmdb_id)
-      if res
-        puts "Movie refreshed. tmdb_id: #{tmdb_id}"
-        updated_movies << tmdb_id
-        sleep 0.01
-      else
-        break
-      end
+      TmdbHandler.tmdb_handler_update_movie(tmdb_id)
+      puts "Movie refreshed. tmdb_id: #{tmdb_id}"
+      updated_movies << tmdb_id
+      sleep 0.01
     end
 
     puts "*** Updated_movies: count: #{updated_movies.count}. tmdb_ids: #{updated_movies}"

--- a/lib/tasks/update_tmdb_data.rake
+++ b/lib/tasks/update_tmdb_data.rake
@@ -1,0 +1,32 @@
+# rake "tmdb_data:refresh"
+# from console: Rake::Task["tmdb_data:refresh"].invoke
+
+TIME_FRAME = 1.week.ago
+BATCH_SIZE = 50
+
+namespace :tmdb_data do
+  desc 'refresh tmdb_data'
+  task :refresh => :environment do
+    tmdb_ids = Movie
+      .where('updated_at < ?', TIME_FRAME)
+      .order(updated_at: :asc)
+      .limit(BATCH_SIZE)
+      .pluck(:tmdb_id)
+
+    puts "*** Refreshing #{tmdb_ids.count} movies..."
+    updated_movies = []
+
+    tmdb_ids.each do |tmdb_id|
+      res = TmdbHandler.tmdb_handler_update_movie(tmdb_id)
+      if res
+        puts "Movie refreshed. tmdb_id: #{tmdb_id}"
+        updated_movies << tmdb_id
+        sleep 0.01
+      else
+        break
+      end
+    end
+
+    puts "*** Updated_movies: count: #{updated_movies.count}. tmdb_ids: #{updated_movies}"
+  end
+end

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -88,7 +88,7 @@ module TmdbHandler
 
     movie_url = "#{BASE_URL}/movie/#{tmdb_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=trailers,credits,similar,releases"
     api_result = HTTParty.get(movie_url).deep_symbolize_keys rescue nil
-    Raven.capture_message("API request failed for tmdb_id: #{tmdb_id}") && return unless api_result && api_result[:id] == tmdb_id
+    Raven.capture_message("API request failed for tmdb_id: #{tmdb_id}") && return unless api_result && api_result[:id].to_s == tmdb_id.to_s
     updated_data = MovieMore.tmdb_info(api_result)
 
     if movie.title != updated_data.title

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -89,7 +89,6 @@ module TmdbHandler
     movie_url = "#{BASE_URL}/movie/#{tmdb_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=trailers,credits,similar,releases"
     api_result = HTTParty.get(movie_url).deep_symbolize_keys rescue nil
     Raven.capture_message("API request failed for tmdb_id: #{tmdb_id}") && return unless api_result && api_result[:id] == tmdb_id
-
     updated_data = MovieMore.tmdb_info(api_result)
 
     if movie.title != updated_data.title
@@ -114,6 +113,8 @@ module TmdbHandler
       runtime: updated_data.runtime,
       mpaa_rating: updated_data.mpaa_rating
     )
+  rescue ActiveRecord::RecordInvalid => e
+    Raven.capture_message("Movie failed to save: tmdb_id: #{tmdb_id}. Message: #{e.message}") && return
   end
 
   def tmdb_handler_actor_more(actor_id)

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -88,7 +88,7 @@ module TmdbHandler
 
     movie_url = "#{BASE_URL}/movie/#{tmdb_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=trailers,credits,similar,releases"
     api_result = HTTParty.get(movie_url).deep_symbolize_keys rescue nil
-    Raven.capture_message("API request failed for tmdb_id: #{tmdb_id}") && return unless api_result[:id] == tmdb_id
+    Raven.capture_message("API request failed for tmdb_id: #{tmdb_id}") && return unless api_result && api_result[:id] == tmdb_id
 
     updated_data = MovieMore.tmdb_info(api_result)
 

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -88,10 +88,8 @@ module TmdbHandler
     popularity: @movie.popularity, runtime: @movie.runtime, mpaa_rating: @movie.mpaa_rating)
   end
 
-  def self.tmdb_handler_update_movie(tmdb_id)
-    movie = Movie.find_by(tmdb_id: tmdb_id)
-    raise TmdbHandlerError.new("Movie not found in DB: tmdb_id: #{tmdb_id}") unless movie
-
+  def self.tmdb_handler_update_movie(movie)
+    tmdb_id = movie.tmdb_id
     movie_url = "#{BASE_URL}/movie/#{tmdb_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=trailers,credits,similar,releases"
     api_result = HTTParty.get(movie_url).deep_symbolize_keys rescue nil
     raise TmdbHandlerError.new("API request failed for tmdb_id: #{tmdb_id}") unless api_result && api_result[:id].to_s == tmdb_id.to_s

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -1,8 +1,9 @@
 module TmdbHandler
+  BASE_URL = 'https://api.themoviedb.org/3'.freeze
 
   def tmdb_handler_search(query)
     @query = query.titlecase
-    @search_url = "http://api.themoviedb.org/3/search/movie?query=#{query}&api_key=#{ENV['tmdb_api_key']}"
+    @search_url = "#{BASE_URL}/search/movie?query=#{query}&api_key=#{ENV['tmdb_api_key']}"
     @tmdb_response = JSON.parse(open(@search_url).read, symbolize_names: true)
     @discover_results = @tmdb_response[:results]
     if !@discover_results.present?
@@ -17,20 +18,20 @@ module TmdbHandler
   end
 
   def tmdb_handler_movie_autocomplete(query)
-    @search_url = "http://api.themoviedb.org/3/search/movie?query=#{query}&api_key=#{ENV['tmdb_api_key']}"
+    @search_url = "#{BASE_URL}/search/movie?query=#{query}&api_key=#{ENV['tmdb_api_key']}"
     @tmdb_response = JSON.parse(open(@search_url).read, symbolize_names: true)
     @autocomplete_results = @tmdb_response[:results].map{ |result| result[:title] }.uniq
   end
 
   def tmdb_handler_person_autocomplete(query)
-    @search_url = "http://api.themoviedb.org/3/search/multi?query=#{query}&api_key=#{ENV['tmdb_api_key']}"
+    @search_url = "#{BASE_URL}/search/multi?query=#{query}&api_key=#{ENV['tmdb_api_key']}"
     @tmdb_response = JSON.parse(open(@search_url).read, symbolize_names: true)
     @person_results = @tmdb_response[:results].select{ |result| result[:media_type] == "person"}
     @autocomplete_results = @person_results.map{ |result| result[:name] }.uniq
   end
 
   def tmdb_handler_movie_more(id)
-    @movie_url = "https://api.themoviedb.org/3/movie/#{id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=trailers,credits,similar,releases"
+    @movie_url = "#{BASE_URL}/movie/#{id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=trailers,credits,similar,releases"
     @result = JSON.parse(open(@movie_url).read, symbolize_names: true)
     @movie = MovieMore.parse_result(@result)
 
@@ -39,7 +40,7 @@ module TmdbHandler
   end
 
   def tmdb_handler_similar_movies(tmdb_id, page)
-    @movie_url = "https://api.themoviedb.org/3/movie/#{tmdb_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=trailers,credits,releases,similar&page=#{page}"
+    @movie_url = "#{BASE_URL}/movie/#{tmdb_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=trailers,credits,releases,similar&page=#{page}"
     @result = JSON.parse(open(@movie_url).read, symbolize_names: true)
     @similar_results = @result[:similar][:results]
     @total_pages = @result[:similar][:total_pages]
@@ -58,7 +59,7 @@ module TmdbHandler
   end #similar movies
 
   def tmdb_handler_full_cast(tmdb_id)
-    @movie_url = "https://api.themoviedb.org/3/movie/#{tmdb_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=credits"
+    @movie_url = "#{BASE_URL}/movie/#{tmdb_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=credits"
     @result = JSON.parse(open(@movie_url).read, symbolize_names: true)
     tmdb_handler_movie_more(tmdb_id)
     @credits = @result[:credits]
@@ -120,33 +121,33 @@ module TmdbHandler
   end
 
   def tmdb_handler_person_detail_search(person_id)
-    api_bio_url = "https://api.themoviedb.org/3/person/#{person_id}?api_key=#{ENV['tmdb_api_key']}"
+    api_bio_url = "#{BASE_URL}/person/#{person_id}?api_key=#{ENV['tmdb_api_key']}"
     bio_results = JSON.parse(open(api_bio_url).read, symbolize_names: true)
     @person_profile = MoviePersonProfile.parse_result(bio_results)
 
-    api_movie_credits_url = "https://api.themoviedb.org/3/person/#{person_id}/movie_credits?api_key=#{ENV['tmdb_api_key']}"
+    api_movie_credits_url = "#{BASE_URL}/person/#{person_id}/movie_credits?api_key=#{ENV['tmdb_api_key']}"
     movie_credits_results = JSON.parse(open(api_movie_credits_url).read, symbolize_names: true)
     @person_movie_credits = MoviePersonCredits.parse_result(movie_credits_results)
 
-    api_tv_credits_url = "https://api.themoviedb.org/3/person/#{person_id}/tv_credits?api_key=#{ENV['tmdb_api_key']}"
+    api_tv_credits_url = "#{BASE_URL}/person/#{person_id}/tv_credits?api_key=#{ENV['tmdb_api_key']}"
     tv_credits_results = JSON.parse(open(api_tv_credits_url).read, symbolize_names: true)
     @person_tv_credits = TVPersonCredits.parse_result(tv_credits_results)
   end
 
   def tmdb_handler_actor_credit(credit_id)
-    @credit_url = "https://api.themoviedb.org/3/credit/#{credit_id}?api_key=#{ENV['tmdb_api_key']}"
+    @credit_url = "#{BASE_URL}/credit/#{credit_id}?api_key=#{ENV['tmdb_api_key']}"
     @credit_results = JSON.parse(open(@credit_url).read, symbolize_names: true)
     @credit = TVActorCredit.parse_results(@credit_results)
   end
 
   def tmdb_handler_tv_series(show_id)
-    @show_url = "https://api.themoviedb.org/3/tv/#{show_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=credits"
+    @show_url = "#{BASE_URL}/tv/#{show_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=credits"
     @show_results = JSON.parse(open(@show_url).read, symbolize_names: true)
     @series = TVSeries.parse_results(@show_results, show_id)
   end
 
   def tmdb_handler_tv_season(show_id, season_number)
-    @season_url = "https://api.themoviedb.org/3/tv/#{show_id}/season/#{season_number}?api_key=#{ENV['tmdb_api_key']}&append_to_response=credits"
+    @season_url = "#{BASE_URL}/tv/#{show_id}/season/#{season_number}?api_key=#{ENV['tmdb_api_key']}&append_to_response=credits"
     @show_id = show_id
     @season_results = JSON.parse(open(@season_url).read, symbolize_names: true)
     tmdb_handler_tv_series(show_id)
@@ -203,7 +204,7 @@ module TmdbHandler
     @year_select = params[:year_select]
 
     if @actor.present?
-      @actor1_url = "https://api.themoviedb.org/3/search/person?query=#{@actor}&api_key=#{ENV['tmdb_api_key']}"
+      @actor1_url = "#{BASE_URL}/search/person?query=#{@actor}&api_key=#{ENV['tmdb_api_key']}"
       @actor1_search_result = JSON.parse(open(@actor1_url).read, symbolize_names: true)[:results]
       if !@actor1_search_result.present?
         return @not_found = "No results for '#{actor}'."
@@ -213,7 +214,7 @@ module TmdbHandler
     end
 
     if @actor2.present?
-      @actor2_url = "https://api.themoviedb.org/3/search/person?query=#{@actor2}&api_key=#{ENV['tmdb_api_key']}"
+      @actor2_url = "#{BASE_URL}/search/person?query=#{@actor2}&api_key=#{ENV['tmdb_api_key']}"
       @actor2_search_result = JSON.parse(open(@actor2_url).read, symbolize_names: true)[:results]
       if !@actor2_search_result.present?
         return @not_found = "No results for '#{actor2}'."
@@ -245,7 +246,7 @@ module TmdbHandler
     else
       @year_search = "primary_release_date.gte=1800-01-01"
     end
-    @discover_url = "https://api.themoviedb.org/3/discover/movie?#{@year_search}&with_genres=#{@genre}&with_people=#{@people}&with_companies=#{@company}&certification_country=US&certification=#{@mpaa_rating}&sort_by=#{@sort_by}.desc&page=#{@page}&api_key=#{ENV['tmdb_api_key']}"
+    @discover_url = "#{BASE_URL}/discover/movie?#{@year_search}&with_genres=#{@genre}&with_people=#{@people}&with_companies=#{@company}&certification_country=US&certification=#{@mpaa_rating}&sort_by=#{@sort_by}.desc&page=#{@page}&api_key=#{ENV['tmdb_api_key']}"
     @discover_results = JSON.parse(open(@discover_url).read, symbolize_names: true)[:results]
     @movies = MovieSearch.parse_results(@discover_results)
     @total_pages = JSON.parse(open(@discover_url).read, symbolize_names: true)[:total_pages]

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -99,7 +99,7 @@ module TmdbHandler
     updated_data = MovieMore.tmdb_info(api_result)
 
     if movie.title != updated_data.title
-      puts "Movie title doesn't match. tmdb_id: #{tmdb_id}. Current title: #{movie.title}. Updated title: #{updated_data.title}"
+      puts "Movie title doesn't match. Movie not updated. tmdb_id: #{tmdb_id}. Current title: #{movie.title}. Title in TMDB: #{updated_data.title}"
       return
     end
 

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -99,8 +99,8 @@ module TmdbHandler
     updated_data = MovieMore.tmdb_info(api_result)
 
     if movie.title != updated_data.title
-      msg = "Movie title doesn't match. tmdb_id: #{tmdb_id}. Current title: #{movie.title}. Updated title: #{updated_data.title}"
-      raise TmdbHandlerError.new(msg)
+      puts "Movie title doesn't match. tmdb_id: #{tmdb_id}. Current title: #{movie.title}. Updated title: #{updated_data.title}"
+      return
     end
 
     movie.update!(
@@ -118,7 +118,8 @@ module TmdbHandler
       vote_average: updated_data.vote_average,
       popularity: updated_data.popularity,
       runtime: updated_data.runtime,
-      mpaa_rating: updated_data.mpaa_rating
+      mpaa_rating: updated_data.mpaa_rating,
+      updated_at: Time.current
     )
   rescue ActiveRecord::RecordInvalid => error
     raise TmdbHandlerError.new(error.message)

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -103,7 +103,6 @@ module TmdbHandler
       raise TmdbHandlerError.new(msg)
     end
 
-
     movie.update!(
       title: updated_data.title,
       imdb_id: updated_data.imdb_id,

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -84,7 +84,8 @@ module TmdbHandler
 
   def self.tmdb_handler_update_movie(tmdb_id)
     movie = Movie.find_by(tmdb_id: tmdb_id)
-    Raven.capture_message("movie not found in our db: #{tmdb_id}") && return unless movie
+    Raven.capture_message("movie not found in our db: #{tmdb_id}") if defined?(Raven) && movie.blank?
+    return unless movie
 
     movie_url = "#{BASE_URL}/movie/#{tmdb_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=trailers,credits,similar,releases"
     api_result = HTTParty.get(movie_url).deep_symbolize_keys rescue nil

--- a/spec/factories/movies.rb
+++ b/spec/factories/movies.rb
@@ -16,6 +16,20 @@ FactoryBot.define do
     factory :invalid_movie do
       tmdb_id { nil }
     end
-  end
 
+    factory :movie_in_tmdb do
+      title { 'Fargo' }
+      tmdb_id { 275 }
+      imdb_id { 'tt0116282' }
+      backdrop_path { '/747dgDfL5d8esobk7h4odaOFhUq.jpg' }
+      poster_path { '/kKpORM0G7xDvJGQiXpQ0wUp9Dwo.jpg' }
+      release_date { 'Fri, 08 Mar 1996' }
+      overview { 'Jerry, a small-town Minnesota car salesman' }
+      trailer { 'h2tY82z3xXU' }
+      vote_average { 7.9 }
+      popularity { 17.27 }
+      mpaa_rating { 'R' }
+      director { 'Joel Coen' }
+    end
+  end
 end

--- a/spec/helpers/movies_helper_spec.rb
+++ b/spec/helpers/movies_helper_spec.rb
@@ -14,7 +14,11 @@ describe MoviesHelper, type: :helper do
 
     it 'returns an image tag if the movie has a poster path' do
       allow(movie).to receive(:poster_path).and_return('tester')
-      expect(helper.image_for(movie)).to eq(image_tag("http://image.tmdb.org/t/p/w185#{movie.poster_path}"))
+      expect(helper.image_for(movie)).to eq(
+        image_tag("http://image.tmdb.org/t/p/w185#{movie.poster_path}",
+          title: movie.title,
+          alt: movie.title)
+        )
     end
   end
 

--- a/spec/modules/tmdb_handler_spec.rb
+++ b/spec/modules/tmdb_handler_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe TmdbHandler, type: :module do
   let(:movie) { create(:movie_in_tmdb) }
   let(:tmdb_id) { movie.tmdb_id }
-  subject { TmdbHandler.tmdb_handler_update_movie(tmdb_id) }
+  subject { TmdbHandler.tmdb_handler_update_movie(movie) }
 
   context 'with a valid movie' do
     it 'returns true' do
@@ -17,11 +17,6 @@ RSpec.describe TmdbHandler, type: :module do
         expect{ subject }.to change{ movie.reload.updated_at }
       end
     end
-  end
-
-  context 'when movie is not found in db' do
-    let(:tmdb_id) { 'wrong' }
-    it { expect{subject}.to raise_error(TmdbHandler::TmdbHandlerError) }
   end
 
   context 'when no movie found from api response' do
@@ -67,16 +62,6 @@ RSpec.describe TmdbHandler, type: :module do
     it 'raises an error and does not update the movie' do
       VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie', record: :new_episodes) do
         expect{subject}.to raise_error(TmdbHandler::TmdbHandlerError).and not_change{ movie.reload.updated_at }
-      end
-    end
-  end
-
-  context 'when tmdb_id is passed as a string' do
-    let(:tmdb_id) { movie.tmdb_id.to_s }
-
-    it 'returns true' do
-      VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie', record: :new_episodes) do
-        expect(subject).to eq(true)
       end
     end
   end

--- a/spec/modules/tmdb_handler_spec.rb
+++ b/spec/modules/tmdb_handler_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe TmdbHandler, type: :module do
+  let(:movie) { create(:movie_in_tmdb) }
+  let(:tmdb_id) { movie.tmdb_id }
+  subject { TmdbHandler.tmdb_handler_update_movie(tmdb_id) }
+
+  context 'with a valid movie' do
+    it 'returns true' do
+      VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie', record: :new_episodes) do
+        expect(subject).to eq(true)
+      end
+    end
+
+    it 'updates the movie' do
+      VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie', record: :new_episodes) do
+        expect{ subject }.to change{ movie.reload.updated_at }
+      end
+    end
+  end
+
+  context 'when movie is not found in db' do
+    let(:tmdb_id) { 'wrong' }
+    it { is_expected.to be_nil }
+    it { expect{subject}.not_to change{ movie.reload.updated_at } }
+  end
+
+  context 'when no movie found from api response' do
+    before { movie.update(tmdb_id: 'wrong')}
+    it 'returns nil' do
+      VCR.use_cassette('tmdb_handler_update_movie_with_an_invalid_movie', record: :new_episodes) do
+        expect(subject).to be_nil
+      end
+    end
+
+    it 'does not update the movie' do
+      VCR.use_cassette('tmdb_handler_update_movie_with_an_invalid_movie', record: :new_episodes) do
+        expect{ subject }.not_to change{ movie.reload.updated_at }
+      end
+    end
+  end
+
+  context 'when the title does not match' do
+    before { movie.update(title: 'Fargowrong') }
+    it 'returns nil' do
+      VCR.use_cassette('tmdb_handler_update_movie_with_wrong_title', record: :new_episodes) do
+        expect(subject).to be_nil
+      end
+    end
+
+    it 'does not update the movie' do
+      VCR.use_cassette('tmdb_handler_update_movie_with_wrong_title', record: :new_episodes) do
+        expect{ subject }.not_to change{ movie.reload.updated_at }
+      end
+    end
+  end
+
+  context 'with outdated info' do
+    let(:wrong_mpaa_rating) { 'G' }
+    let(:correct_mpaa_rating) { 'R' }
+    before { movie.update(mpaa_rating: wrong_mpaa_rating) }
+    it 'updates movie with latest tmdb info' do
+      VCR.use_cassette('tmdb_handler_update_movie_with_outdated_info', record: :new_episodes) do
+        subject
+        expect(movie.reload.mpaa_rating).to eq(correct_mpaa_rating)
+      end
+    end
+  end
+
+  context 'when the movie fails to save' do
+    let(:dupe_movie) { build(:movie, tmdb_id: movie.tmdb_id) }
+    before { dupe_movie.save(validate: false) }
+
+    it 'returns nil' do
+      VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie', record: :new_episodes) do
+        expect(subject).to be_nil
+      end
+    end
+  end
+end

--- a/spec/modules/tmdb_handler_spec.rb
+++ b/spec/modules/tmdb_handler_spec.rb
@@ -35,9 +35,15 @@ RSpec.describe TmdbHandler, type: :module do
 
   context 'when the title does not match' do
     before { movie.update(title: 'Fargowrong') }
-    it 'raises an error and does not update the movie' do
+    it 'does not raise an error' do
       VCR.use_cassette('tmdb_handler_update_movie_with_wrong_title', record: :new_episodes) do
-        expect{subject}.to raise_error(TmdbHandler::TmdbHandlerError).and not_change{ movie.reload.updated_at }
+        expect{subject}.not_to raise_error
+      end
+    end
+
+    it 'does not update the movie' do
+      VCR.use_cassette('tmdb_handler_update_movie_with_wrong_title', record: :new_episodes) do
+        expect{ subject }.not_to change{ movie.reload.updated_at }
       end
     end
   end

--- a/spec/modules/tmdb_handler_spec.rb
+++ b/spec/modules/tmdb_handler_spec.rb
@@ -21,36 +21,23 @@ RSpec.describe TmdbHandler, type: :module do
 
   context 'when movie is not found in db' do
     let(:tmdb_id) { 'wrong' }
-    it { is_expected.to be_nil }
-    it { expect{subject}.not_to change{ movie.reload.updated_at } }
+    it { expect{subject}.to raise_error(TmdbHandler::TmdbHandlerError) }
   end
 
   context 'when no movie found from api response' do
     before { movie.update(tmdb_id: 'wrong')}
-    it 'returns nil' do
+    it 'raises an error and does not update the movie' do
       VCR.use_cassette('tmdb_handler_update_movie_with_an_invalid_movie', record: :new_episodes) do
-        expect(subject).to be_nil
-      end
-    end
-
-    it 'does not update the movie' do
-      VCR.use_cassette('tmdb_handler_update_movie_with_an_invalid_movie', record: :new_episodes) do
-        expect{ subject }.not_to change{ movie.reload.updated_at }
+        expect{subject}.to raise_error(TmdbHandler::TmdbHandlerError).and not_change{ movie.reload.updated_at }
       end
     end
   end
 
   context 'when the title does not match' do
     before { movie.update(title: 'Fargowrong') }
-    it 'returns nil' do
+    it 'raises an error and does not update the movie' do
       VCR.use_cassette('tmdb_handler_update_movie_with_wrong_title', record: :new_episodes) do
-        expect(subject).to be_nil
-      end
-    end
-
-    it 'does not update the movie' do
-      VCR.use_cassette('tmdb_handler_update_movie_with_wrong_title', record: :new_episodes) do
-        expect{ subject }.not_to change{ movie.reload.updated_at }
+        expect{subject}.to raise_error(TmdbHandler::TmdbHandlerError).and not_change{ movie.reload.updated_at }
       end
     end
   end
@@ -71,9 +58,9 @@ RSpec.describe TmdbHandler, type: :module do
     let(:dupe_movie) { build(:movie, tmdb_id: movie.tmdb_id) }
     before { dupe_movie.save(validate: false) }
 
-    it 'returns nil' do
+    it 'raises an error and does not update the movie' do
       VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie', record: :new_episodes) do
-        expect(subject).to be_nil
+        expect{subject}.to raise_error(TmdbHandler::TmdbHandlerError).and not_change{ movie.reload.updated_at }
       end
     end
   end

--- a/spec/modules/tmdb_handler_spec.rb
+++ b/spec/modules/tmdb_handler_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe TmdbHandler, type: :module do
     end
   end
 
-  context 'when the movie fails to save' do
+  xcontext 'when the movie fails to save' do
     let(:dupe_movie) { build(:movie, tmdb_id: movie.tmdb_id) }
     before { dupe_movie.save(validate: false) }
 

--- a/spec/modules/tmdb_handler_spec.rb
+++ b/spec/modules/tmdb_handler_spec.rb
@@ -77,4 +77,14 @@ RSpec.describe TmdbHandler, type: :module do
       end
     end
   end
+
+  context 'when tmdb_id is passed as a string' do
+    let(:tmdb_id) { movie.tmdb_id.to_s }
+
+    it 'returns true' do
+      VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie', record: :new_episodes) do
+        expect(subject).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,6 +38,8 @@ unless ENV['TRAVIS']
   Capybara.javascript_driver = :chrome
 end
 
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
 RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :controller
   config.include Warden::Test::Helpers

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,6 +1,6 @@
 VCR.configure do |config|
   config.cassette_library_dir = "spec/vcr_cassettes"
   config.hook_into :webmock
-  config.allow_http_connections_when_no_cassette = true
+  config.allow_http_connections_when_no_cassette = false
   config.ignore_localhost = true
 end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,6 +1,6 @@
 VCR.configure do |config|
   config.cassette_library_dir = "spec/vcr_cassettes"
   config.hook_into :webmock
-  config.allow_http_connections_when_no_cassette = false
+  config.allow_http_connections_when_no_cassette = true
   config.ignore_localhost = true
 end


### PR DESCRIPTION
## Related Issues & PRs
Closes #193

Adds a rake task to get latest data from TMDB and update the data in our DB accordingly. 

FYI, as of 5/17/20, there are 1,752 movies in our DB.

## Problems Solved
* The primary goal is to fix the broken images. But it's also good to regularly update the movie data from TMDB. There's a separate issue for that here: https://github.com/mikevallano/tmdb-moviequeue/issues/195

## Screenshots
N/A

## Things Learned
* The code written 4 years ago isn't great 😄 . 
* Scheduling tasks in Heroku is a thing (grassy @lortza )
