### PR TITLE
199: tweak rake task for better results

### DIFF
--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -92,13 +92,12 @@ module TmdbHandler
     tmdb_id = movie.tmdb_id
     movie_url = "#{BASE_URL}/movie/#{tmdb_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=trailers,credits,similar,releases"
     api_result = HTTParty.get(movie_url).deep_symbolize_keys rescue nil
-    raise TmdbHandlerError.new("API request failed for tmdb_id: #{tmdb_id}") unless api_result && api_result[:id].to_s == tmdb_id.to_s
+    raise TmdbHandlerError.new("API request failed for movie: #{movie.title}") unless api_result && api_result[:id].to_s == tmdb_id.to_s
 
     updated_data = MovieMore.tmdb_info(api_result)
 
     if movie.title != updated_data.title
-      puts "Movie title doesn't match. Movie not updated. tmdb_id: #{tmdb_id}. Current title: #{movie.title}. Title in TMDB: #{updated_data.title}"
-      return
+      puts "Movie title doesn't match. tmdb_id: #{tmdb_id}. Current title: #{movie.title}. Title in TMDB: #{updated_data.title}"
     end
 
     movie.update!(
@@ -120,7 +119,7 @@ module TmdbHandler
       updated_at: Time.current
     )
   rescue ActiveRecord::RecordInvalid => error
-    raise TmdbHandlerError.new(error.message)
+    raise TmdbHandlerError.new("#{movie.title} failed update. #{error.message}")
   end
 
   def tmdb_handler_actor_more(actor_id)

--- a/spec/modules/tmdb_handler_spec.rb
+++ b/spec/modules/tmdb_handler_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe TmdbHandler, type: :module do
       end
     end
 
-    it 'does not update the movie' do
+    it 'still updates the movie' do
       VCR.use_cassette('tmdb_handler_update_movie_with_wrong_title', record: :new_episodes) do
-        expect{ subject }.not_to change{ movie.reload.updated_at }
+        expect{ subject }.to change{ movie.reload.updated_at }
       end
     end
   end


### PR DESCRIPTION
## Related Issues & PRs
Closes #199 

## Problems Solved
- Does not stop a movie from being updated if the title doesn't match. After running ~ 300 updates, the title is usually just a slight tweak, but it _is_ the same movie
- If the API call fails, output the actual movie title, since the `tmdb_id` doesn't tell us anything

## Screenshots
N/A

## Things Learned
- Heroku never actually ran the rake task (at least that I could see in the command line), so I used the Heroku browser console, which also allows exporting the terminal session as a text file 👍 
