### PR TITLE
202: Move rake task to scheduler for Heroku

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,4 +1,4 @@
-# To run the rake task: rake "tmdb_data:refresh"
+# To run the rake task: rake tmdb_data:refresh
 # To run from console: Rake::Task["tmdb_data:refresh"].invoke
 
 TIME_FRAME = (ENV['tmdb_refresh_time_frame_days'] || 7).to_i.days.ago


### PR DESCRIPTION
## Related Issues & PRs
Closes #202

## Problems Solved
* Move rake task to `/scheduler.rake` as described on Heroku for running scheduled tasks

## Screenshots
n/a

## Things Learned
* Learned about Heroku scheduler 🤞 
