### PR TITLE
203: Don't raise error when tmdb_id is not found. Improve output

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -17,7 +17,7 @@ namespace :tmdb_data do
 
     movies.each do |movie|
       TmdbHandler.tmdb_handler_update_movie(movie)
-      puts "Movie refreshed. tmdb_id: #{movie.tmdb_id}"
+      puts "Movie refreshed. #{movie.title}. tmdb_id: #{movie.tmdb_id}"
       updated_movies << movie.tmdb_id
       sleep 0.01
     end

--- a/spec/modules/tmdb_handler_spec.rb
+++ b/spec/modules/tmdb_handler_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe TmdbHandler, type: :module do
     before { movie.update(tmdb_id: 'wrong')}
     it 'raises an error and does not update the movie' do
       VCR.use_cassette('tmdb_handler_update_movie_with_an_invalid_movie', record: :new_episodes) do
-        expect{subject}.to raise_error(TmdbHandler::TmdbHandlerError).and not_change{ movie.reload.updated_at }
+        expect{ subject }.not_to raise_error(TmdbHandler::TmdbHandlerError)
+        expect{ subject }.not_to change{ movie.reload.updated_at }
       end
     end
   end


### PR DESCRIPTION
## Related Issues & PRs
Closes #203

## Problems Solved
* If the `tmdb_id` isn't found (like the mysterious affair at styles), just skip it rather than raising an error.
* Improves output to include movie title, for easier double checking

## Screenshots
n/a

## Things Learned
* 🤔 
