### PR TITLE
214: Fix Youtube URL parsing

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -78,11 +78,16 @@ class MoviesController < ApplicationController
     end
   end #set movie
 
+  private
+
   def required_params
-    if params[:trailer].present?
-      params[:trailer] = params[:trailer].gsub('https://www.youtube.com/watch?v=', '')
-    end
+    params[:trailer] = parse_youtube_url(params[:trailer]) if params[:trailer].present?
     params.permit(:trailer)
   end
 
+  def parse_youtube_url(trailer)
+    return trailer unless trailer.include?('youtube.com')
+    uri = Addressable::URI.parse(trailer)
+    uri.query_values["v"] if uri.query_values
+  end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -81,13 +81,13 @@ class MoviesController < ApplicationController
   private
 
   def required_params
-    params[:trailer] = parse_youtube_url(params[:trailer]) if params[:trailer].present?
+    trailer_url = params[:trailer]
+    params[:trailer] = trailer_url.include?('youtube.com') ? youtube_id : trailer_url
     params.permit(:trailer)
   end
 
-  def parse_youtube_url(trailer)
-    return trailer unless trailer.include?('youtube.com')
-    uri = Addressable::URI.parse(trailer)
-    uri.query_values["v"] if uri.query_values
+  def youtube_id
+    uri = Addressable::URI.parse(params[:trailer])
+    uri.query_values['v'] if uri.query_values
   end
 end

--- a/app/views/movies/_movie_show.html.erb
+++ b/app/views/movies/_movie_show.html.erb
@@ -59,7 +59,7 @@
 
             <% if @movie.trailer.present? %>
               <div class="embed-container">
-                <iframe src="https://www.youtube.com/embed/<%= @movie.trailer %>?rel=0"></iframe>
+                <iframe src="https://www.youtube.com/embed/<%= @movie.trailer %>?rel=0" allowfullscreen></iframe>
               </div>
             <% else %>
               <p class="sidebar-button trailer-button">

--- a/spec/controllers/movies_controller_spec.rb
+++ b/spec/controllers/movies_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe MoviesController, type: :controller do
   let(:movie) { create(:movie) }
   let(:list) { create(:list, owner_id: user.id) }
   let(:listing) { create(:listing, list_id: list.id, movie_id: movie.id) }
+  let(:youtube_id) { '44urisjfk' }
 
   shared_examples_for 'with logged in user' do
 
@@ -27,7 +28,6 @@ RSpec.describe MoviesController, type: :controller do
 
     describe 'PATCH #update' do
       it 'updates the movie' do
-        youtube_id = '88ur8usk'
         patch :update,
               { id: movie.id,
                 tmdb_id: movie.tmdb_id,
@@ -36,7 +36,6 @@ RSpec.describe MoviesController, type: :controller do
       end
 
       it 'strips full youtube url' do
-        youtube_id = '44urisjfk'
         patch :update,
               { id: movie.id,
                 tmdb_id: movie.tmdb_id,
@@ -44,11 +43,19 @@ RSpec.describe MoviesController, type: :controller do
         expect(movie.reload.trailer).to eq(youtube_id)
       end
 
+      it 'strips youtube url with additional params' do
+        patch :update,
+              { id: movie.id,
+                tmdb_id: movie.tmdb_id,
+                trailer: "https://www.youtube.com/watch?v=#{youtube_id}&ab_channel=A24" }
+        expect(movie.reload.trailer).to eq(youtube_id)
+      end
+
       it 'redirects to the movie show page, trailer-section' do
         patch :update,
               { id: movie.id,
                 tmdb_id: movie.tmdb_id,
-                trailer: 'tester' }
+                trailer: "https://www.youtube.com/watch?v=#{youtube_id}" }
         expect(response).to redirect_to(movie_path(movie, anchor: 'trailer-section'))
       end
     end

--- a/spec/controllers/movies_controller_spec.rb
+++ b/spec/controllers/movies_controller_spec.rb
@@ -58,6 +58,31 @@ RSpec.describe MoviesController, type: :controller do
                 trailer: "https://www.youtube.com/watch?v=#{youtube_id}" }
         expect(response).to redirect_to(movie_path(movie, anchor: 'trailer-section'))
       end
+
+      context 'with invalid or non-youtube trailers' do
+        # TODO: This illustrates how it currently works.
+        # In https://github.com/mikevallano/tmdb-moviequeue/issues/218,
+        # the plan is to restrict the form field to valid youtube urls,
+        # only allow admins access to this feature,
+        # or add a new join table so random users can't modify movies directly.
+        it 'leaves non-youtube urls as-is' do
+          trailer = 'https://www.example.com'
+          patch :update,
+                { id: movie.id,
+                  tmdb_id: movie.tmdb_id,
+                  trailer: trailer }
+          expect(movie.reload.trailer).to eq(trailer)
+        end
+
+        it 'handles empty trailer urls' do
+          trailer = ''
+          patch :update,
+                { id: movie.id,
+                  tmdb_id: movie.tmdb_id,
+                  trailer: trailer }
+          expect(movie.reload.trailer).to eq(trailer)
+        end
+      end
     end
 
   end #shared example with logged in user


### PR DESCRIPTION
## Related Issues & PRs
Closes #214

## Problems Solved
* Now you can paste youtube urls with whatever additional url params are there
* FULLSCREEN MODE now works! 🎉 

## Screenshots
Fullscreen mode and licecap don't work together, but it works!
![trailer_after](https://user-images.githubusercontent.com/7945260/98752892-c30f0d00-2388-11eb-9a55-acc6290c0529.gif)

## Things Learned
* I modified the code from this SO post: https://stackoverflow.com/a/6557013
* We should probably put some sort of validation in place to ensure nobody can enter invalid stuffs. Since we don't currently have it, I'll open a separate issue for it.
