### PR TITLE
218: Restrict trailer edit to admin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,11 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  def restrict_to_admin!
+    return if current_user.admin?
+    redirect_to :back, alert: 'Must be an admin to access that feature'
+  end
+
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :email, :password, :password_confirmation, :remember_me])
     devise_parameter_sanitizer.permit(:sign_in, keys: [:login, :username, :email, :password, :remember_me])

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,6 @@
 class MoviesController < ApplicationController
   before_action :authenticate_user!
+  before_action :restrict_to_admin!, only: :update
   before_action :set_movie, only: [:update]
   include SortingHandler
   include TmdbHandler

--- a/app/views/movies/_movie_show.html.erb
+++ b/app/views/movies/_movie_show.html.erb
@@ -67,6 +67,7 @@
               </p>
             <% end %> <!-- #if trailer present -->
 
+          <% if current_user.admin? %>
             <%= form_tag(movie_path(@movie), { class: "form-class", id: "add-trailer", method: :patch } ) do %>
               <%= text_field_tag :trailer, nil,
                                   { placeholder: trailer_placeholder_text(@movie),
@@ -75,6 +76,7 @@
               <%= hidden_field_tag(:tmdb_id, @movie.tmdb_id) %>
               <%= submit_tag trailer_button_text(@movie), id: "add-trailer-btn", class: "form-control-submit", disabled: 'disabled' %>
             <% end %> <!-- # tag form loop -->
+          <% end %> <!-- # if admin? -->
 
             <% if @production_companies.present? %> <!-- # if @production_companies.present? -->
               <p><strong>Production Companies:</strong>

--- a/spec/controllers/movies_controller_spec.rb
+++ b/spec/controllers/movies_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe MoviesController, type: :controller do
 
   let(:user) { create(:user) }
+  let(:admin_user) { create(:user, username: "anne") }
   let(:current_user) { login_with user }
   let(:invalid_user) { login_with nil }
   let(:movie) { create(:movie) }
@@ -27,63 +28,80 @@ RSpec.describe MoviesController, type: :controller do
     end
 
     describe 'PATCH #update' do
-      it 'updates the movie' do
-        patch :update,
-              { id: movie.id,
-                tmdb_id: movie.tmdb_id,
-                trailer: youtube_id }
-        expect(movie.reload.trailer).to eq(youtube_id)
-      end
-
-      it 'strips full youtube url' do
-        patch :update,
-              { id: movie.id,
-                tmdb_id: movie.tmdb_id,
-                trailer: "https://www.youtube.com/watch?v=#{youtube_id}" }
-        expect(movie.reload.trailer).to eq(youtube_id)
-      end
-
-      it 'strips youtube url with additional params' do
-        patch :update,
-              { id: movie.id,
-                tmdb_id: movie.tmdb_id,
-                trailer: "https://www.youtube.com/watch?v=#{youtube_id}&ab_channel=A24" }
-        expect(movie.reload.trailer).to eq(youtube_id)
-      end
-
-      it 'redirects to the movie show page, trailer-section' do
-        patch :update,
-              { id: movie.id,
-                tmdb_id: movie.tmdb_id,
-                trailer: "https://www.youtube.com/watch?v=#{youtube_id}" }
-        expect(response).to redirect_to(movie_path(movie, anchor: 'trailer-section'))
-      end
-
-      context 'with invalid or non-youtube trailers' do
-        # TODO: This illustrates how it currently works.
-        # In https://github.com/mikevallano/tmdb-moviequeue/issues/218,
-        # the plan is to restrict the form field to valid youtube urls,
-        # only allow admins access to this feature,
-        # or add a new join table so random users can't modify movies directly.
-        it 'leaves non-youtube urls as-is' do
-          trailer = 'https://www.example.com'
+      context 'with an admin' do
+        let(:current_user) { login_with(admin_user) }
+        it 'updates the movie' do
           patch :update,
                 { id: movie.id,
                   tmdb_id: movie.tmdb_id,
-                  trailer: trailer }
-          expect(movie.reload.trailer).to eq(trailer)
+                  trailer: youtube_id }
+          expect(movie.reload.trailer).to eq(youtube_id)
         end
 
-        it 'handles empty trailer urls' do
-          trailer = ''
+        it 'strips full youtube url' do
           patch :update,
                 { id: movie.id,
                   tmdb_id: movie.tmdb_id,
-                  trailer: trailer }
-          expect(movie.reload.trailer).to eq(trailer)
+                  trailer: "https://www.youtube.com/watch?v=#{youtube_id}" }
+          expect(movie.reload.trailer).to eq(youtube_id)
+        end
+
+        it 'strips youtube url with additional params' do
+          patch :update,
+                { id: movie.id,
+                  tmdb_id: movie.tmdb_id,
+                  trailer: "https://www.youtube.com/watch?v=#{youtube_id}&ab_channel=A24" }
+          expect(movie.reload.trailer).to eq(youtube_id)
+        end
+
+        it 'redirects to the movie show page, trailer-section' do
+          patch :update,
+                { id: movie.id,
+                  tmdb_id: movie.tmdb_id,
+                  trailer: "https://www.youtube.com/watch?v=#{youtube_id}" }
+          expect(response).to redirect_to(movie_path(movie, anchor: 'trailer-section'))
+        end
+
+        context 'with invalid or non-youtube trailers' do
+          # TODO: This illustrates how it currently works.
+          # In https://github.com/mikevallano/tmdb-moviequeue/issues/218,
+          # the plan is to restrict the form field to valid youtube urls,
+          # only allow admins access to this feature,
+          # or add a new join table so random users can't modify movies directly.
+          it 'leaves non-youtube urls as-is' do
+            trailer = 'https://www.example.com'
+            patch :update,
+                  { id: movie.id,
+                    tmdb_id: movie.tmdb_id,
+                    trailer: trailer }
+            expect(movie.reload.trailer).to eq(trailer)
+          end
+
+          it 'handles empty trailer urls' do
+            trailer = ''
+            patch :update,
+                  { id: movie.id,
+                    tmdb_id: movie.tmdb_id,
+                    trailer: trailer }
+            expect(movie.reload.trailer).to eq(trailer)
+          end
         end
       end
-    end
+
+      context 'with a non-admin' do
+        let(:current_user) { login_with(user) }
+        it 'does not update the movie' do
+          @request.env['HTTP_REFERER'] = movie_path(movie)
+          patch :update,
+                  { id: movie.id,
+                    tmdb_id: movie.tmdb_id,
+                    trailer: youtube_id }
+            expect(movie.reload.trailer).not_to eq(youtube_id)
+            expect(response).to redirect_to(movie_path(movie))
+            expect(flash[:alert]).to eq('Must be an admin to access that feature')
+        end
+      end
+    end # describe #update
 
   end #shared example with logged in user
 

--- a/spec/features/movies_feature_spec.rb
+++ b/spec/features/movies_feature_spec.rb
@@ -63,13 +63,19 @@ RSpec.feature "Movies feature spec", :type => :feature do
 
       scenario 'update the movie trailer', js: true do
         youtube_id = '73829hsuhf'
-        sign_in_user(user)
+        sign_in_user(anne) #anne is an "admin"
         visit(movie_path(movie))
         fill_in 'trailer', with: youtube_id
         click_button('add-trailer-btn')
         url = URI.parse(current_url)
         expect("#{url}").to include('trailer-section') #redirects to anchor tag
         expect(movie.reload.trailer).to eq(youtube_id) #updates the trailer
+      end
+
+      scenario 'non-admin shoudl not see trailer btn' do
+        sign_in_user(user)
+        visit(movie_path(movie))
+        expect(page).not_to have_selector('#add-trailer-btn')
       end
 
       scenario "update movie button retrieves latest info from API" do
@@ -80,7 +86,7 @@ RSpec.feature "Movies feature spec", :type => :feature do
         VCR.use_cassette('update_movie') do
           click_link("update_movie_link_movie_show")
         end
-        expect(page).to have_content("98 min")
+        expect(page).to have_content("1h 38m")
       end
 
       context "the movie on the show page is on one of the user's lists" do


### PR DESCRIPTION
## Related Issues & PRs
Closes #218

## Problems Solved
* Only allow admins to edit movie data. Prevents randos from adding crap data.

## Screenshots
**Non-admins view without the trailer link**
<img width="866" alt="non-admin-after" src="https://user-images.githubusercontent.com/7945260/99328534-e7b02c80-2841-11eb-9e7f-2e59b245d36d.png">

**This wouldn't happen, but shows the back end validation**
![trailer_admin_after](https://user-images.githubusercontent.com/7945260/99328537-e848c300-2841-11eb-975c-327465f0dce3.gif)

## Things Learned
* Front end tests are still borked 🤷 
