### PR TITLE
223: Add admin boolean

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
   - export DISPLAY=:99.0
 script:
-  - bundle exec rake db:setup
+  - bundle exec rake db:migrate RAILS_ENV=test
   - bundle exec rspec --exclude-pattern "**/features/*_spec.rb"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,11 +48,6 @@ class User < ActiveRecord::Base
   has_many :watched_movies, through: :screenings,
   :source => :movie
 
-  def admin?
-    admins = %w(roscoe mikevallano anne)
-    admins.include?(self.username)
-  end
-
   def all_lists
     (self.lists | self.member_lists).uniq
   end

--- a/db/migrate/20151218195511_drop_genres.rb
+++ b/db/migrate/20151218195511_drop_genres.rb
@@ -1,5 +1,5 @@
 class DropGenres < ActiveRecord::Migration
   def change
-    drop_table :genre_movies
+    drop_table :genre_movies if table_exists?(:genre_movies)
   end
 end

--- a/db/migrate/20151218195706_drop_genre_table.rb
+++ b/db/migrate/20151218195706_drop_genre_table.rb
@@ -1,5 +1,5 @@
 class DropGenreTable < ActiveRecord::Migration
   def change
-    drop_table :genres
+    drop_table :genres if table_exists?(:genres)
   end
 end

--- a/db/migrate/20201120004329_add_admin_to_users.rb
+++ b/db/migrate/20201120004329_add_admin_to_users.rb
@@ -1,0 +1,9 @@
+class AddAdminToUsers < ActiveRecord::Migration
+  def up
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+
+  def down
+    remove_column :users, :admin
+  end
+end

--- a/spec/controllers/movies_controller_spec.rb
+++ b/spec/controllers/movies_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe MoviesController, type: :controller do
 
   let(:user) { create(:user) }
-  let(:admin_user) { create(:user, username: "anne") }
+  let(:admin_user) { create(:user, admin: true) }
   let(:current_user) { login_with user }
   let(:invalid_user) { login_with nil }
   let(:movie) { create(:movie) }

--- a/spec/features/movies_feature_spec.rb
+++ b/spec/features/movies_feature_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Movies feature spec", :type => :feature do
     let(:username) { FFaker::Internet.user_name }
     let(:user) { create(:user) }
     let(:user2) { create(:user) }
-    let(:anne) { create(:user, username: "anne") }
+    let(:admin_user) { create(:user, admin: true) }
     let(:list) { create(:list, owner_id: user.id) }
     let(:movie) { create(:movie, title: "Fargo", genres: ["Crime"]) }
     let(:movie2) { create(:movie) }
@@ -63,7 +63,7 @@ RSpec.feature "Movies feature spec", :type => :feature do
 
       scenario 'update the movie trailer', js: true do
         youtube_id = '73829hsuhf'
-        sign_in_user(anne) #anne is an "admin"
+        sign_in_user(admin_user)
         visit(movie_path(movie))
         fill_in 'trailer', with: youtube_id
         click_button('add-trailer-btn')
@@ -79,7 +79,7 @@ RSpec.feature "Movies feature spec", :type => :feature do
       end
 
       scenario "update movie button retrieves latest info from API" do
-        sign_in_user(anne) #anne is an "admin"
+        sign_in_user(admin_user)
         fargo
         visit(movie_path(fargo))
         expect(fargo.runtime).to eq(90)


### PR DESCRIPTION
## Related Issues & PRs
Closes #223

## Problems Solved
* Adds a proper boolean field to determine admins.

## Screenshots
N/A

## Things Learned
* We still don't have a way to _assign_ admin, but that's not going to be a problem for the foreseeable future. After the deploy, I'll update the records directly in the Rails console. I thought about doing it in the migration, but it seemed a bit insecure to add that in the codebase 🤷 
