### PR TITLE
225: Use URI and CGI instead of addressable to parse trailer url

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -88,7 +88,7 @@ class MoviesController < ApplicationController
   end
 
   def youtube_id
-    uri = Addressable::URI.parse(params[:trailer])
-    uri.query_values['v'] if uri.query_values
+    uri = URI.parse(params[:trailer])
+    CGI::parse(uri.query)['v']&.first if uri.query
   end
 end


### PR DESCRIPTION
## Related Issues & PRs
Closes #225

## Problems Solved
* Fix error when adding a trailer.

Apparently `addressable`, needs to be added as a gem. I opted for (what I believe is) built in [URI](https://docs.ruby-lang.org/en/2.1.0/URI.html) and [CGI](https://ruby-doc.org/stdlib-2.5.3/libdoc/cgi/rdoc/CGI.html#class-CGI-label-Parameters) to do the same thing.

## Screenshots
![trailer_after](https://user-images.githubusercontent.com/7945260/100151742-3293fa80-2e67-11eb-8167-4c5305c266e5.gif)

## Things Learned
* Not sure why it worked locally and on CI. I guess, be careful when referencing libraries 🤷 
