### PR TITLE
Add link to movie poster view

### DIFF
--- a/app/helpers/movie_person_profiles_helper.rb
+++ b/app/helpers/movie_person_profiles_helper.rb
@@ -7,4 +7,8 @@ module MoviePersonProfilesHelper
     date = profile.birthday.to_date.stamp('January 1st, 2018')
     profile.deathday.blank? ? "#{date} (Age: #{profile.age})" : "#{date}, Deceased (Age: #{profile.age})"
   end
+
+  def actor_movie_posters_uri(actor)
+    "#{root_url}/tmdb/actor_search?actor=#{actor.name.gsub(' ', '+')}"
+  end
 end

--- a/app/helpers/movie_person_profiles_helper.rb
+++ b/app/helpers/movie_person_profiles_helper.rb
@@ -9,6 +9,6 @@ module MoviePersonProfilesHelper
   end
 
   def actor_movie_posters_uri(actor)
-    "#{root_url}/tmdb/actor_search?actor=#{actor.name.gsub(' ', '+')}"
+    "#{root_url}tmdb/actor_search?actor=#{actor.name.gsub(' ', '+')}"
   end
 end

--- a/app/views/tmdb/_movie_credits.html.erb
+++ b/app/views/tmdb/_movie_credits.html.erb
@@ -1,4 +1,7 @@
-<h3>Movie Credits (<%= @person_movie_credits.actor.size %>)</h3>
+<h3>
+  <%= link_to 'Movie Poster View', actor_movie_posters_uri(person_profile), style: 'float: right;' %>
+  Movie Credits (<%= @person_movie_credits.actor.size %>)
+</h3>
 <ul>
   <% @person_movie_credits.actor.each do |credit| %>
     <li><%= link_to credit.title, movie_more_path(tmdb_id: "#{credit.tmdb_id}") %>

--- a/app/views/tmdb/actor_more.html.erb
+++ b/app/views/tmdb/actor_more.html.erb
@@ -13,7 +13,7 @@
   <div class="row">
     <div class="credits">
 
-      <%= render "movie_credits" %>
+      <%= render partial: "movie_credits", locals: { person_profile: @person_profile } %>
 
       <%= render "tv_credits" %>
 

--- a/spec/helpers/movie_person_profiles_helper_spec.rb
+++ b/spec/helpers/movie_person_profiles_helper_spec.rb
@@ -3,10 +3,9 @@
 require 'rails_helper'
 
 describe MoviePersonProfilesHelper, type: :helper do
-  let(:profile) { build(:movie_person_profile) }
+  let(:profile) { build(:movie_person_profile, name: 'Geoff Jefferson') }
   let(:living_profile) { build(:living_movie_person_profile) }
   let(:deceased_profile) { build(:deceased_movie_person_profile) }
-
 
   describe '#display_birthday_info' do
     it 'includes the word version of the birthdate in the returned string' do
@@ -41,6 +40,14 @@ describe MoviePersonProfilesHelper, type: :helper do
       profile.birthday = ''
 
       expect(display_birthday_info(profile)).to eq('Not available')
+    end
+  end
+
+  describe '#actor_movie_posters_uri' do
+    it "generates a uri based on the actor's name" do
+      expected_segment = 'tmdb/actor_search?actor=Geoff+Jefferson'
+      actual_uri = actor_movie_posters_uri(profile)
+      expect(actual_uri).to include(expected_segment)
     end
   end
 end


### PR DESCRIPTION
## Related Issues & PRs
Closes #228

## Problems Solved
We wanted a simple link to get us between the actor bio and the view where we see the posters of all of the movies they were in. This adds a link to the top of the "movie credits" section of the actor bio page that lets us get to that movie poster view. It's simple, but it works. I was considering putting something prettier and more stand-out-looking on the page, but I wasn't sure where to put it where it wouldn't be awkward. Any ideas?

## Screenshots
<img width="975" alt="Screen Shot 2021-03-04 at 7 03 37 PM" src="https://user-images.githubusercontent.com/8680712/110051962-5dba9f80-7d1c-11eb-8da0-9bd88d578254.png">
