### PR TITLE
Remove awkward gap between image and buttons in modal on tablet

### DIFF
--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -12,9 +12,7 @@
       <div class="modal-body">
         <div class="row">
         <div class="col-xs-3">
-          <div class="row">
             <%= link_to image_for(movie), link_to_movie(movie), id: "movie_more_link_movie_partial" %>
-          </div> <!-- row -->
           <div class="watch-info">
             <%= render 'movies/movie_screening', movie: movie %>
             <%= render "movies/movie_watch_info", movie: movie %>


### PR DESCRIPTION
## Problems Solved
There is an awkward gap between image and buttons in modal on tablet. This PR resolves it.

## Screenshots
Before
<img width="960" alt="Screen Shot 2021-04-27 at 1 18 48 PM" src="https://user-images.githubusercontent.com/8680712/116292311-2801c800-a75b-11eb-8c25-fc1938b41b30.png">


After
<img width="885" alt="Screen Shot 2021-04-27 at 1 12 05 PM" src="https://user-images.githubusercontent.com/8680712/116291997-d8230100-a75a-11eb-8295-cb2cafc6ce39.png">
<img width="347" alt="Screen Shot 2021-04-27 at 1 12 18 PM" src="https://user-images.githubusercontent.com/8680712/116292000-d8bb9780-a75a-11eb-8359-fcc21074c249.png">



## Things Learned
* We have some sections that identify themselves with bootstrap classes and we should be naming things better.