### PR TITLE
Fix broken movie link on mobile

### DIFF
--- a/app/views/movies/_movie_partial_loop.html.erb
+++ b/app/views/movies/_movie_partial_loop.html.erb
@@ -19,7 +19,6 @@
             <%= link_to image_for(movie), movie_path(movie) %>
           <% else %>
             <%= link_to image_for(movie), movie_more_path(tmdb_id: movie.tmdb_id) %>
-            <%#= link_to image_for(movie), movie_modal_path(tmdb_id: movie.tmdb_id), remote: true, data: { target: "#myModal_#{movie.tmdb_id}" }, id: "modal_link_#{movie.tmdb_id}" %>
           <% end %>
         </p>
 

--- a/app/views/movies/_movie_partial_loop.html.erb
+++ b/app/views/movies/_movie_partial_loop.html.erb
@@ -4,6 +4,7 @@
       <article class="tile-cover-pic">
         <!-- MODAL TRIGGER -->
         <p id="modal-trigger">
+          <!-- Always display the modal on desktop -->
           <%= link_to image_for(movie), movie_modal_path(tmdb_id: movie.tmdb_id, list_id: @list&.id),
                                         remote: true,
                                         data: { target: "#myModal_#{movie.tmdb_id}" },
@@ -13,7 +14,13 @@
         </p>
 
         <p id="modal-trigger-mobile">
-          <%= link_to image_for(movie), movie_path(movie) %>
+          <!-- Get to a show page on mobile regardless of movie object persistence -->
+          <% if movie.is_a?(Movie) %>
+            <%= link_to image_for(movie), movie_path(movie) %>
+          <% else %>
+            <%= link_to image_for(movie), movie_more_path(tmdb_id: movie.tmdb_id) %>
+            <%#= link_to image_for(movie), movie_modal_path(tmdb_id: movie.tmdb_id), remote: true, data: { target: "#myModal_#{movie.tmdb_id}" }, id: "modal_link_#{movie.tmdb_id}" %>
+          <% end %>
         </p>
 
         <div id="movies_partial_<%= "#{movie.tmdb_id}" %>"></div>


### PR DESCRIPTION
Back in PR #179, I "fixed" the problem where I wouldn't have to interact with the modal on mobile -- preferring to go straight to the show page -- and in the process introduced a bug. The movies search page results are composed of a mix of both `MovieSearch` and `Movie` objects. Clicking on a movie cover derived from a `Movie` object would successfully take you to a show page, but clicking on one from a `MovieSearch` object would throw an error.

<img src="https://user-images.githubusercontent.com/8680712/116326777-db35e580-a78a-11eb-90e9-6de82ac9a6d8.gif" width="200">

I've updated this link so that:
* a modal always displays on tablet through desktop sizes
* on mobile, the image links to a show page for `Movie` objects
* on mobile, the image links to a "movie more" page for `MovieSearch` objects

<img src="https://user-images.githubusercontent.com/8680712/116327225-ed645380-a78b-11eb-899c-c3f9960f47e8.gif" width="200">

Items of note:
* This code is janky. It uses an `is_a?` to decide which link to use. I'd love to refactor this, but wow there is a lot going on with a bunch of instance variables and it will be a much deeper dive than I'm prepared to handle in this fix PR.
* Performance concerns: ~We may experience some performance issues. The modal call felt pretty quick. This feels a little slower. 🤷 Though that's just a _feeling_ right now. It may or may not be slower than going to our show page. We may need to make another call to the API to get the details to populate that "movie more" page.  I'm looking into this now.~ RESOLVED: The API call made by the modal is the same as the one I used for this fix, so there shouldn't be any performance concerns outside of any extra time it takes to load the backsplash image.


### Rolling Back
To easily restore the functionality that opens a modal for `MovieSearch` objects on mobile instead of hitting the api, and without reintroducing the bug, replace `app/views/movies/_movie_partial_loop.html.erb` line 21 with 
```
<%= link_to image_for(movie), movie_modal_path(tmdb_id: movie.tmdb_id), remote: true, data: { target: "#myModal_#{movie.tmdb_id}" }, id: "modal_link_#{movie.tmdb_id}" %>
```
