### PR TITLE
Add gem better_errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem 'sentry-raven'
 
 group :development do
   gem 'web-console', '~> 2.0'
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,10 @@ GEM
     ast (2.4.0)
     awesome_print (1.8.0)
     bcrypt (3.1.13)
+    better_errors (2.9.1)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
@@ -86,6 +90,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.1.5)
+    erubi (1.10.0)
     erubis (2.7.0)
     execjs (2.7.0)
     factory_bot (5.0.2)
@@ -332,6 +337,8 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print
+  better_errors
+  binding_of_caller
   capybara
   capybara-email
   coffee-rails (~> 4.1.0)


### PR DESCRIPTION
## Problems Solved
The Better Errors gem gives us... better errors 😆 including access to a console where you can check values of any variables available to you at the moment of failure. While the Rails default has some of the features this gem has now, I prefer the better_errors interface. 

## Screenshots
Before
<img width="1029" alt="Screen Shot 2021-05-16 at 4 54 00 PM" src="https://user-images.githubusercontent.com/8680712/118413919-5fcba380-b667-11eb-9ac2-01a4031cef7e.png">


After
<img width="1025" alt="Screen Shot 2021-05-16 at 4 51 35 PM" src="https://user-images.githubusercontent.com/8680712/118413908-462a5c00-b667-11eb-9c23-b32bb1901b18.png">


## About the Work
* this is a development-env-only change
* it does not affect app code
* it just makes dev life nicer
