### PR TITLE
Change language around our personal movie rating

### DIFF
--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -81,10 +81,9 @@ module MoviesHelper
 
   def star_rating(movie)
     if current_user.rated_movies.include?(movie)
-      "IMDB: #{movie.vote_average} ★, Me: #{movie.ratings.by_user(current_user).first.value } ★"
+      "IMDB: #{movie.vote_average} ★, Me: #{movie.ratings.by_user(current_user).first.value } ♥"
     else
       "#{movie.vote_average} ★"
     end
   end
-
 end #MoviesHelper

--- a/app/views/movies/_movie_rating.html.erb
+++ b/app/views/movies/_movie_rating.html.erb
@@ -2,8 +2,13 @@
 
   <% if current_user.rated_movies.include?(movie) %> <!-- #if movie has been rated -->
 
-    <p><icon class="fa fa-star"></icon><span class="pseudo-header"> My Rating:</span> <%= movie.ratings.by_user(current_user).first.value %>/10 <%= link_to '<i class="fa fa-pencil"></i> Edit Rating'.html_safe, movie_rating_path(movie, movie.ratings.by_user(current_user).first), id: "show_rating_link_movies_partial" %>
-
+    <p>
+      <icon class="fa fa-heart"></icon>
+      <span class="pseudo-header"> My Enjoyment:</span> <%= movie.ratings.by_user(current_user).first.value %>/10 
+      <%= link_to '<i class="fa fa-pencil"></i> Edit Rating'.html_safe,
+                  movie_rating_path(movie, movie.ratings.by_user(current_user).first),
+                  id: "show_rating_link_movies_partial"
+      %>
     </p>
 
   <% else %> <!-- #if movie has been rated -->
@@ -15,7 +20,7 @@
         <%= hidden_field_tag :list_id, @list.id if @list.present? %>
         <%= hidden_field_tag :from, "movies_index" if !@list.present? %>
         <%= hidden_field_tag :page, params[:page] %>
-        <icon class="fa fa-star "></icon> <%= f.label "Rate this Movie:", class: "pseudo-header" %><br>
+        <icon class="fa fa-heart"></icon> <%= f.label "How much did you like it?", class: "pseudo-header" %><br>
         <%= f.select(:value, Rating::VALUES, { prompt: "Out of 10" }, { class: "form-control", id: "rating_value_field" }) %>
         <%= f.submit "Rate", id: "rating_submit_button_rating_form", class: "form-control-submit" %>
       <% end %> <!-- # rating form -->


### PR DESCRIPTION
## Related Issues & PRs
Closes #239

This PR changes the language we use around our own ratings of a movie. Instead of needing to rate a movie with stars, we're now simply talking about how much we liked the movie. This takes away any mental overhead about what makes a movie "good" and focuses on whether or not we enjoyed it. That's what will help us to decide whether we want to watch this movie again.

## Screenshots
<img width="539" alt="Screen Shot 2021-07-04 at 2 14 01 PM" src="https://user-images.githubusercontent.com/8680712/124396990-a4240900-dcd2-11eb-804a-2923c486d833.png">

<img width="366" alt="Screen Shot 2021-07-04 at 2 19 16 PM" src="https://user-images.githubusercontent.com/8680712/124397026-d9c8f200-dcd2-11eb-978c-4fc60e9facc9.png">

<img width="479" alt="Screen Shot 2021-07-04 at 2 14 12 PM" src="https://user-images.githubusercontent.com/8680712/124396991-a5553600-dcd2-11eb-9d38-628fc7f1610b.png">


## Things Learned
* I messed around a little bit with displaying solid and outlined hearts to show the rating, but it looked pretty terrible with 10 items. If our rating system stopped at 5, it might look okay.
