### PR TITLE
Add tv show search

### DIFF
--- a/app/assets/javascripts/z.js
+++ b/app/assets/javascripts/z.js
@@ -8,14 +8,18 @@ $(document).ready(function(){
       $("#overlay-modal").show(); }
     });
 
+  $("#autocomplete-tv-series-search-submit").autocomplete({
+    source: $("#autocomplete-tv-series-search-submit").data("autocomplete-source"),
+    minLength: 4,
+    select: function(event, ui) {
+      $("#autocomplete-tv-series-search-submit").val(ui.item.value);
+      $(this).closest("form").submit();
+      $("#overlay-modal").show(); }
+    });
+
   $( ".autocomplete-search-field" ).autocomplete({
     minLength: 4,
     source: $(".autocomplete-search-field").data("autocomplete-source")
-  });
-
-  $( ".autocomplete-tv-series-search" ).autocomplete({
-    minLength: 4,
-    source: $(".autocomplete-tv-series-search").data("autocomplete-source")
   });
 
   $('#header-movie-search, ul.ui-autocomplete').css({

--- a/app/assets/javascripts/z.js
+++ b/app/assets/javascripts/z.js
@@ -1,21 +1,18 @@
 $(document).ready(function(){
-  $(".autocomplete-auto-submit").autocomplete({
-    source: $(".autocomplete-auto-submit").data("autocomplete-source"),
-    minLength: 4,
-    select: function(event, ui) {
-      $(".autocomplete-auto-submit").val(ui.item.value);
-      $(this).closest("form").submit();
-      $("#overlay-modal").show(); }
-    });
+  $('.autocomplete-auto-submit').each(function(){
+    let form = $(this)
+    let source = form.data('autocomplete-source')
 
-  $("#autocomplete-tv-series-search-submit").autocomplete({
-    source: $("#autocomplete-tv-series-search-submit").data("autocomplete-source"),
-    minLength: 4,
-    select: function(event, ui) {
-      $("#autocomplete-tv-series-search-submit").val(ui.item.value);
-      $(this).closest("form").submit();
-      $("#overlay-modal").show(); }
-    });
+    form.autocomplete({
+      source: source,
+      minLength: 4,
+      select: function (event, ui) {
+        $(this).closest(".autocomplete-auto-submit").val(ui.item.value);
+        $(this).closest("form").submit();
+        $("#overlay-modal").show();
+      }
+    })
+  });
 
   $( ".autocomplete-search-field" ).autocomplete({
     minLength: 4,

--- a/app/assets/javascripts/z.js
+++ b/app/assets/javascripts/z.js
@@ -13,6 +13,11 @@ $(document).ready(function(){
     source: $(".autocomplete-search-field").data("autocomplete-source")
   });
 
+  $( ".autocomplete-tv-series-search" ).autocomplete({
+    minLength: 4,
+    source: $(".autocomplete-tv-series-search").data("autocomplete-source")
+  });
+
   $('#header-movie-search, ul.ui-autocomplete').css({
     'position': 'relative',
     'max-width': '455px'

--- a/app/assets/stylesheets/movies.scss
+++ b/app/assets/stylesheets/movies.scss
@@ -30,7 +30,7 @@ article.tile-cover-pic {
   position: relative;
   background-color: $missing-poster-background-color;
   float: left;
-  margin: -10px 10px 10px 0px;
+  margin: 10px 10px 10px 0px;
   width: $index-poster-width;
   height: $index-poster-height;
   word-wrap: break-word;

--- a/app/assets/stylesheets/movies.scss
+++ b/app/assets/stylesheets/movies.scss
@@ -34,9 +34,10 @@ article.tile-cover-pic {
   width: $index-poster-width;
   height: $index-poster-height;
   word-wrap: break-word;
-  padding: 5%;
+  padding: .25rem;
   text-align: center;
   color: black;
+  overflow: hidden;
   p {
     margin: 30% 0%;
     font-size: 150%;

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -90,6 +90,12 @@ class TmdbController < ApplicationController
     tmdb_handler_actor_credit(@credit_id)
   end
 
+  def tv_series_search
+    if show_title = params[:show_title] || params[:show_title_header]
+      @show_title = I18n.transliterate(show_title)
+      @tv_shows = tmdb_handler_tv_series_search(show_title)
+    end
+  end
   def tv_series
     @show_id = params[:show_id]
     @actor_id = params[:actor_id]

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -91,11 +91,18 @@ class TmdbController < ApplicationController
   end
 
   def tv_series_search
-    if show_title = params[:show_title] || params[:show_title_header]
-      @show_title = I18n.transliterate(show_title)
-      @tv_shows = tmdb_handler_tv_series_search(show_title)
+    query = show_title = params[:show_title] || params[:show_title_header]
+    if query.present?
+      @query = I18n.transliterate(query)
+      @search_results = tmdb_handler_tv_series_search(query)
     end
   end
+
+  def tv_series_autocomplete
+    autocomplete_results = tmdb_handler_tv_series_autocomplete(params[:term])
+    render json: autocomplete_results
+  end
+
   def tv_series
     @show_id = params[:show_id]
     @actor_id = params[:actor_id]

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -1,13 +1,11 @@
 module MoviesHelper
-
   def image_for(movie)
     if movie.poster_path.present?
       image_tag("http://image.tmdb.org/t/p/w185#{movie.poster_path}", title: movie.title, alt: movie.title)
     else
-      render "movies/movie_missing_poster", movie: movie
-      # image_tag('placeholder.png')
-    end #if
-  end #image_for
+      render "shared/missing_poster", title: movie.title
+    end
+  end
 
   def link_to_movie(movie)
     if movie.in_db

--- a/app/helpers/tv_series_helper.rb
+++ b/app/helpers/tv_series_helper.rb
@@ -1,0 +1,11 @@
+module TvSeriesHelper
+
+  def image_for_tv_poster(series)
+    title = series.show_name
+    if series.poster_path.present?
+      image_tag("http://image.tmdb.org/t/p/w185#{series.poster_path}", title: title, alt: title)
+    else
+      render "shared/missing_poster", title: title
+    end
+  end
+end

--- a/app/models/tv_series.rb
+++ b/app/models/tv_series.rb
@@ -1,6 +1,5 @@
 class TVSeries
-  def initialize(show_id, first_air_date, last_air_date, show_name, backdrop_path, poster_path, number_of_episodes, number_of_seasons, overview, seasons, actors)
-
+  def initialize(show_id:, first_air_date:, last_air_date:, show_name:, backdrop_path:, poster_path:, number_of_episodes:, number_of_seasons:, overview:, seasons:, actors:)
     @show_id = show_id
     @first_air_date = first_air_date
     @last_air_date = last_air_date
@@ -12,10 +11,27 @@ class TVSeries
     @overview = overview
     @seasons = seasons
     @actors = actors
-
-  end #init
+  end
 
   attr_accessor :show_id, :first_air_date, :last_air_date, :show_name, :backdrop_path, :poster_path, :number_of_episodes, :number_of_seasons, :overview, :seasons, :actors
+
+  def self.parse_search_results(results)
+    results.map do|result|
+      TVSeries.new(
+        show_id: result[:id],
+        first_air_date: Date.parse(result[:first_air_date])&.stamp("1/2/2001"),
+        last_air_date: nil,
+        show_name: result[:name],
+        backdrop_path: result[:backdrop_path],
+        poster_path: result[:poster_path],
+        number_of_episodes: nil,
+        number_of_seasons: nil,
+        overview: result[:overview],
+        seasons: nil,
+        actors: nil
+      )
+    end
+  end
 
   def self.parse_results(result, show_id)
     @show_id = show_id
@@ -29,7 +45,19 @@ class TVSeries
     @overview = result[:overview]
     @seasons = (1..(result[:number_of_seasons])).to_a if result[:number_of_seasons].present?
     @actors = TVCast.parse_results(result[:credits][:cast])
-    @series = TVSeries.new(@show_id, @first_air_date, @last_air_date, @show_name, @backdrop_path, @poster_path, @number_of_episodes, @number_of_seasons, @overview, @seasons, @actors)
-  end #parse results
 
-end #class
+    @series = TVSeries.new(
+      show_id: @show_id,
+      first_air_date: @first_air_date,
+      last_air_date: @last_air_date,
+      show_name: @show_name,
+      backdrop_path: @backdrop_path,
+      poster_path: @poster_path,
+      number_of_episodes: @number_of_episodes,
+      number_of_seasons: @number_of_seasons,
+      overview: @overview,
+      seasons: @seasons,
+      actor: @actors
+    )
+  end
+end

--- a/app/models/tv_series.rb
+++ b/app/models/tv_series.rb
@@ -17,9 +17,10 @@ class TVSeries
 
   def self.parse_search_results(results)
     results.map do|result|
+      first_air_date = Date.parse(result[:first_air_date])&.stamp("1/2/2001") if result[:first_air_date].present?
       TVSeries.new(
         show_id: result[:id],
-        first_air_date: Date.parse(result[:first_air_date])&.stamp("1/2/2001"),
+        first_air_date: first_air_date,
         last_air_date: nil,
         show_name: result[:name],
         backdrop_path: result[:backdrop_path],

--- a/app/models/tv_series.rb
+++ b/app/models/tv_series.rb
@@ -58,7 +58,7 @@ class TVSeries
       number_of_seasons: @number_of_seasons,
       overview: @overview,
       seasons: @seasons,
-      actor: @actors
+      actors: @actors
     )
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -50,8 +50,9 @@
         <li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Search Options <span class="caret"></span></a>
           <ul class="dropdown-menu">
-            <li><%= link_to "Search by Title", api_search_path, id: "movie_search_nav_link" %></li>
             <li><%= link_to "Search by Actor", actor_search_path, id: "actor_search_nav_link" %></li>
+            <li><%= link_to "Search by Movie Title", api_search_path, id: "movie_search_nav_link" %></li>
+            <li><%= link_to "Search by TV Series", tv_series_search_path, id: "movie_search_nav_link" %></li>
             <li role="separator" class="divider"></li>
             <li><%= link_to "Advanced Search", discover_search_path, id: "discover_search_nav_link" %></li>
             <li role="separator" class="divider"></li>

--- a/app/views/movies/_movie_missing_poster.erb
+++ b/app/views/movies/_movie_missing_poster.erb
@@ -1,3 +1,0 @@
-<div class="missing-poster">
-	<p><%= movie.title %></p>
-</div> <!-- missing-poster -->

--- a/app/views/shared/_missing_poster.erb
+++ b/app/views/shared/_missing_poster.erb
@@ -1,0 +1,3 @@
+<div class="missing-poster">
+	<p><%= title %></p>
+</div>

--- a/app/views/tmdb/search.html.erb
+++ b/app/views/tmdb/search.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, "Search by Movie Title") %>
 <% if !@movie_title.present? %>
 
-  <h1 id="search_by_title_header">Search for a Movie by Title:</h1>
+  <h1 id="search_by_title_header">Search for a Movie by Title</h1>
 
   <%= form_tag '/tmdb/search', { class: "form-class", id: "movie-title-search", role: "form", method: :get } do %>
     <%= text_field_tag :movie_title, nil, class: "form-control search-form search-form autocomplete-auto-submit", id: "movie_field_movie_search", placeholder: "Enter Movie Title", data: { autocomplete_source: movie_autocomplete_path }  %>
@@ -17,7 +17,7 @@
       <p class="button-main"><%= link_to "Search Again", api_search_path %> </p>
 
   <% else %> <!-- # if @not_found.present? -->
-    <h2>Movies matching '<%= @query %>':</h2>
+    <h2>Movies matching '<%= @query %>'</h2>
 
     <br>
       <%= form_tag '/tmdb/search', { class: "form-class", id: "movie-title-search-again", role: "form", method: :get } do %>

--- a/app/views/tmdb/tv_series_search.html.erb
+++ b/app/views/tmdb/tv_series_search.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, "Search by TV Show Title") %>
 
-<h1 id="search_by_title_header">Search for a TV Show by Title:</h1>
+<h1 id="search_by_title_header">Search for a TV Show by Title</h1>
 <%= form_tag '/tmdb/tv_series_search', { class: "form-class", id: "show-title-search", role: "form", method: :get } do %>
   <%= text_field_tag :show_title, nil,
     class: "form-control search-form search-form autocomplete-auto-submit",
@@ -17,9 +17,12 @@
 <% end %>
 
 <% if @tv_shows.present? %>
-  <h2>TV Shows matching "<%= @show_title %>":</h2>
-  <br>
-  <% @tv_shows.each do |series| %>
-    <%= link_to image_for_tv_poster(series), tv_series_path(show_id: series.show_id) %>
-  <% end %>
+  <h2>TV Shows matching "<%= @show_title %>"</h2>
+  <div class='row tile-container'>
+    <% @tv_shows.each do |series| %>
+    <article class="tile-cover-pic">
+      <%= link_to image_for_tv_poster(series), tv_series_path(show_id: series.show_id) %>
+    </article>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/tmdb/tv_series_search.html.erb
+++ b/app/views/tmdb/tv_series_search.html.erb
@@ -1,0 +1,25 @@
+<% content_for(:title, "Search by TV Show Title") %>
+
+<h1 id="search_by_title_header">Search for a TV Show by Title:</h1>
+<%= form_tag '/tmdb/tv_series_search', { class: "form-class", id: "show-title-search", role: "form", method: :get } do %>
+  <%= text_field_tag :show_title, nil,
+    class: "form-control search-form search-form autocomplete-auto-submit",
+    id: "tv_series_field_tv_series_search",
+    placeholder: "Enter TV Show Title",
+    data: { autocomplete_source: tv_series_autocomplete_path }  %>
+  <%= submit_tag "Search", id: "search_by_title_button", class: "form-control-submit search-form-submit" %>
+<% end %>
+<br>
+
+<% if @show_title.present? && @tv_shows.blank? %>
+  <h2>Hmm. We couldn't find anything for "<%= @show_title %>".</h2>
+  <p>Check your spelling and try again.</p>
+<% end %>
+
+<% if @tv_shows.present? %>
+  <h2>TV Shows matching "<%= @show_title %>":</h2>
+  <br>
+  <% @tv_shows.each do |series| %>
+    <%= link_to image_for_tv_poster(series), tv_series_path(show_id: series.show_id) %>
+  <% end %>
+<% end %>

--- a/app/views/tmdb/tv_series_search.html.erb
+++ b/app/views/tmdb/tv_series_search.html.erb
@@ -3,25 +3,25 @@
 <h1 id="search_by_title_header">Search for a TV Show by Title</h1>
 <%= form_tag '/tmdb/tv_series_search', { class: "form-class", id: "show-title-search", role: "form", method: :get } do %>
   <%= text_field_tag :show_title, nil,
-    class: "form-control search-form search-form autocomplete-auto-submit",
+    class: "form-control search-form autocomplete-tv-series-search",
     id: "tv_series_field_tv_series_search",
     placeholder: "Enter TV Show Title",
     data: { autocomplete_source: tv_series_autocomplete_path }  %>
-  <%= submit_tag "Search", id: "search_by_title_button", class: "form-control-submit search-form-submit" %>
+  <%= submit_tag "Search", id: "submit_button_tv_series_search", class: "form-control-submit search-form-submit" %>
 <% end %>
 <br>
 
-<% if @show_title.present? && @tv_shows.blank? %>
-  <h2>Hmm. We couldn't find anything for "<%= @show_title %>".</h2>
+<% if @query.present? && @search_results.blank? %>
+  <h2>Hmm. We couldn't find anything for "<%= @query %>".</h2>
   <p>Check your spelling and try again.</p>
 <% end %>
 
-<% if @tv_shows.present? %>
-  <h2>TV Shows matching "<%= @show_title %>"</h2>
+<% if @search_results.present? %>
+  <h2>TV Shows matching "<%= @query %>"</h2>
   <div class='row tile-container'>
-    <% @tv_shows.each do |series| %>
+    <% @search_results.each do |result| %>
     <article class="tile-cover-pic">
-      <%= link_to image_for_tv_poster(series), tv_series_path(show_id: series.show_id) %>
+      <%= link_to image_for_tv_poster(result), tv_series_path(show_id: result.show_id) %>
     </article>
     <% end %>
   </div>

--- a/app/views/tmdb/tv_series_search.html.erb
+++ b/app/views/tmdb/tv_series_search.html.erb
@@ -3,8 +3,7 @@
 <h1 id="search_by_title_header">Search for a TV Show by Title</h1>
 <%= form_tag '/tmdb/tv_series_search', { class: "form-class", id: "show-title-search", role: "form", method: :get } do %>
   <%= text_field_tag :show_title, nil,
-    class: "form-control search-form",
-    id: "autocomplete-tv-series-search-submit",
+    class: "form-control search-form autocomplete-auto-submit",
     placeholder: "Enter TV Show Title",
     data: { autocomplete_source: tv_series_autocomplete_path }  %>
   <%= submit_tag "Search", id: "submit_button_tv_series_search", class: "form-control-submit search-form-submit" %>

--- a/app/views/tmdb/tv_series_search.html.erb
+++ b/app/views/tmdb/tv_series_search.html.erb
@@ -3,8 +3,8 @@
 <h1 id="search_by_title_header">Search for a TV Show by Title</h1>
 <%= form_tag '/tmdb/tv_series_search', { class: "form-class", id: "show-title-search", role: "form", method: :get } do %>
   <%= text_field_tag :show_title, nil,
-    class: "form-control search-form autocomplete-tv-series-search",
-    id: "tv_series_field_tv_series_search",
+    class: "form-control search-form",
+    id: "autocomplete-tv-series-search-submit",
     placeholder: "Enter TV Show Title",
     data: { autocomplete_source: tv_series_autocomplete_path }  %>
   <%= submit_tag "Search", id: "submit_button_tv_series_search", class: "form-control-submit search-form-submit" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
   get 'tmdb/two_actor_search', to: 'tmdb#two_actor_search', as: :two_actor_search
   get 'tmdb/director_search', to: 'tmdb#director_search', as: :director_search
   get 'tmdb/tv_series', to: 'tmdb#tv_series', as: :tv_series
+  get 'tmdb/tv_series_search', to: 'tmdb#tv_series_search', as: :tv_series_search
   get 'tmdb/tv_season', to: 'tmdb#tv_season', as: :tv_season
   get 'tmdb/two_movie_search', to: 'tmdb#two_movie_search', as: :two_movie_search
   get 'tmdb/discover_search', to: 'tmdb#discover_search', as: :discover_search

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
   get 'tmdb/two_movie_search', to: 'tmdb#two_movie_search', as: :two_movie_search
   get 'tmdb/discover_search', to: 'tmdb#discover_search', as: :discover_search
   get 'tmdb/movie_autocomplete', to: 'tmdb#movie_autocomplete', as: :movie_autocomplete
+  get 'tmdb/tv_series_autocomplete', to: 'tmdb#tv_series_autocomplete', as: :tv_series_autocomplete
   get 'tmdb/person_autocomplete', to: 'tmdb#person_autocomplete', as: :person_autocomplete
 
   resources :invites, only: [:create]

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -152,6 +152,19 @@ module TmdbHandler
     @credit = TVActorCredit.parse_results(@credit_results)
   end
 
+  def tmdb_handler_tv_series_search(query)
+    search_url = "#{BASE_URL}/search/tv?query=#{query}&api_key=#{ENV['tmdb_api_key']}"
+    tmdb_response = JSON.parse(open(search_url).read, symbolize_names: true)
+    discover_results = tmdb_response[:results]
+    TVSeries.parse_search_results(discover_results) if discover_results.present?
+  end
+
+  def tmdb_handler_tv_series_autocomplete(query)
+    search_url = "#{BASE_URL}/search/tv?query=#{query}&api_key=#{ENV['tmdb_api_key']}"
+    tmdb_response = JSON.parse(open(search_url).read, symbolize_names: true)
+    tmdb_response[:results].map{ |result| result[:name] }.uniq
+  end
+
   def tmdb_handler_tv_series(show_id)
     @show_url = "#{BASE_URL}/tv/#{show_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=credits"
     @show_results = JSON.parse(open(@show_url).read, symbolize_names: true)

--- a/spec/helpers/movies_helper_spec.rb
+++ b/spec/helpers/movies_helper_spec.rb
@@ -9,7 +9,7 @@ describe MoviesHelper, type: :helper do
       allow(movie).to receive(:poster_path).and_return(nil)
       allow(helper).to receive(:render)
       helper.image_for(movie)
-      expect(helper).to have_received(:render).with("movies/movie_missing_poster", movie: movie)
+      expect(helper).to have_received(:render).with("shared/missing_poster", title: movie.title)
     end
 
     it 'returns an image tag if the movie has a poster path' do


### PR DESCRIPTION
## Problems Solved
We don't currently have a way to search for TV shows on our app. Granted, we built the app to be a MovieQueue™️ 😆 and not a TV tracking app. However, when we're watching some of our favorite TV shows, I find myself going to IMDB to look up actors. I prefer the data and interface of our own app, so I added a simple TV search to get us to the TV Series pages that already exist in our app. 

## Screenshots
The old (current) workflow requires knowing at least one actor's name (tough, considering not may of these folks were famous), searching by their name, going to their bio, scrolling down to their credit for the show, clicking on the show there.
![Kapture 2021-12-19 at 14 34 53](https://user-images.githubusercontent.com/8680712/146689979-8c0407a9-3394-4e1e-80dc-48a6634cde95.gif)


The new way allows me to search for the show directly
![Kapture 2021-12-19 at 14 25 55](https://user-images.githubusercontent.com/8680712/146689737-1fc8d945-f9e7-46ae-81cf-e2ec4b02e4dc.gif)


## Things Learned
* I looked into the results we get for the "full cast" search because you and I were talking about another feature where we'd add an actor's current age to their listing. Birth date is not returned in that response. We'd have to do another call per actor to get that info for that page. 
* As we discussed, having instance variables buried way down in service classes is gnarly for adding features or refactoring. I'm glad to struggle with it today though. It gave me a very clear example (instead of just theory) as to why this pattern is so painful and should be avoided.
* jQuery still flummoxes me. But 🪄 I was able to fix it. 🎉 
