### PR TITLE
Refactor: reduce and centralize instance variables in TVSeries methods

### DIFF
--- a/app/assets/javascripts/z.js
+++ b/app/assets/javascripts/z.js
@@ -13,11 +13,6 @@ $(document).ready(function(){
     source: $(".autocomplete-search-field").data("autocomplete-source")
   });
 
-  $( ".autocomplete-tv-series-search" ).autocomplete({
-    minLength: 4,
-    source: $(".autocomplete-tv-series-search").data("autocomplete-source")
-  });
-
   $('#header-movie-search, ul.ui-autocomplete').css({
     'position': 'relative',
     'max-width': '455px'

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -104,17 +104,15 @@ class TmdbController < ApplicationController
   end
 
   def tv_series
-    @show_id = params[:show_id]
-    @actor_id = params[:actor_id]
-    tmdb_handler_tv_series(@show_id)
+    show_id = params[:show_id]
+    @series = tmdb_handler_tv_series(show_id)
   end
 
   def tv_season
+    show_id = params[:show_id]
     @season_number = params[:season_number]
-    @show_id = params[:show_id]
-    @show_name = params[:show_name]
-    @actor_id = params[:actor_id]
-    tmdb_handler_tv_season(@show_id, @season_number)
+    @series = tmdb_handler_tv_series(show_id)
+    @episodes = tmdb_handler_tv_season(show_id, @season_number)
   end
 
   def two_movie_search

--- a/app/helpers/tv_series_helper.rb
+++ b/app/helpers/tv_series_helper.rb
@@ -1,11 +1,19 @@
 module TvSeriesHelper
-
   def image_for_tv_poster(series)
     title = series.show_name
     if series.poster_path.present?
       image_tag("http://image.tmdb.org/t/p/w185#{series.poster_path}", title: title, alt: title)
     else
       render "shared/missing_poster", title: title
+    end
+  end
+
+  def formatted_season_number(season_number)
+    # to display the correct current season number in the view:
+    if season_number == "0"
+       "Misc/Extras"
+    else
+      "Season #{season_number}"
     end
   end
 end

--- a/app/models/tv_season.rb
+++ b/app/models/tv_season.rb
@@ -1,13 +1,11 @@
 class TVSeason
   def initialize(episode_number, name, air_date, guest_stars, overview, still_path)
-
     @episode_number = episode_number
     @name = name
     @air_date = air_date
     @guest_stars = guest_stars
     @overview = overview
     @still_path = still_path
-
   end #init
 
   attr_accessor :episode_number, :name, :air_date, :guest_stars, :overview, :still_path
@@ -25,6 +23,7 @@ class TVSeason
       end
       @overview = result[:overview]
       @still_path = result[:still_path]
+      # TODO: refactor this into a TvEpisode object
       @episode = TVSeason.new(@episode_number, @name, @air_date, @guest_stars, @overview, @still_path)
       @episodes << @episode
     end

--- a/app/models/tv_series.rb
+++ b/app/models/tv_series.rb
@@ -35,30 +35,23 @@ class TVSeries
   end
 
   def self.parse_results(result, show_id)
-    @show_id = show_id
-    @first_air_date = Date.parse(result[:first_air_date]).stamp("1/2/2001") if result[:first_air_date].present?
-    @last_air_date = Date.parse(result[:last_air_date]).stamp("1/2/2001") if result[:last_air_date].present?
-    @show_name = result[:name]
-    @backdrop_path = result[:backdrop_path]
-    @poster_path = result[:poster_path]
-    @number_of_episodes = result[:number_of_episodes]
-    @number_of_seasons = result[:number_of_seasons]
-    @overview = result[:overview]
-    @seasons = (1..(result[:number_of_seasons])).to_a if result[:number_of_seasons].present?
-    @actors = TVCast.parse_results(result[:credits][:cast])
+    first_air_date = Date.parse(result[:first_air_date]).stamp("1/2/2001") if result[:first_air_date].present?
+    last_air_date = Date.parse(result[:last_air_date]).stamp("1/2/2001") if result[:last_air_date].present?
+    seasons = (1..(result[:number_of_seasons])).to_a if result[:number_of_seasons].present?
+    actors = TVCast.parse_results(result[:credits][:cast])
 
     @series = TVSeries.new(
-      show_id: @show_id,
-      first_air_date: @first_air_date,
-      last_air_date: @last_air_date,
-      show_name: @show_name,
-      backdrop_path: @backdrop_path,
-      poster_path: @poster_path,
-      number_of_episodes: @number_of_episodes,
-      number_of_seasons: @number_of_seasons,
-      overview: @overview,
-      seasons: @seasons,
-      actors: @actors
+      show_id: show_id,
+      first_air_date: first_air_date,
+      last_air_date: last_air_date,
+      show_name: result[:name],
+      backdrop_path: result[:backdrop_path],
+      poster_path: result[:poster_path],
+      number_of_episodes: result[:number_of_episodes],
+      number_of_seasons: result[:number_of_seasons],
+      overview: result[:overview],
+      seasons: seasons,
+      actors: actors
     )
   end
 end

--- a/app/views/tmdb/tv_season.html.erb
+++ b/app/views/tmdb/tv_season.html.erb
@@ -1,17 +1,16 @@
-
-<h1><%= link_to "#{@series.show_name}", tv_series_path(show_id: @show_id) %> <%= @season_number_display %></h1>
-<p class="button-main"><%= link_to "Back to #{@series.show_name}", tv_series_path(show_id: @show_id) %></p>
+<h1><%= link_to "#{@series.show_name}", tv_series_path(show_id: @series.show_id) %> <%= formatted_season_number(@season_number) %></h1>
+<p class="button-main"><%= link_to "Back to #{@series.show_name}", tv_series_path(show_id: @series.show_id) %></p>
 <div class="row">
   <h2>Seasons: |
     <% @series.seasons.each do |season| %>
-     <%= link_to season_number_display(season), tv_season_path(show_id: @show_id, season_number: season, show_name: @series.show_name) %> |
+     <%= link_to season_number_display(season), tv_season_path(show_id: @series.show_id, season_number: season, show_name: @series.show_name) %> |
     <% end %>
   </h2>
 </div> <!-- row -->
 
 <div class="row">
   <% if @series.actors.present? %>
-    <h2><%= @season_number_display %> Cast</h2>
+    <h2><%= formatted_season_number(@season_number) %> Cast</h2>
       <% @series.actors.each do |actor| %>
         <div class="headshot-container">
         <%= headshot_for(actor) %>
@@ -22,14 +21,11 @@
         </div> <!-- headshot-container -->
         <% end %><!-- actors each do -->
   <% end %> <!-- if actors present? -->
-
 </div> <!-- row -->
 
-
 <div class="row">
-  <h2><%= @season_number_display %> Episodes</h2>
+  <h2><%= formatted_season_number(@season_number) %> Episodes</h2>
   <table class="table">
-
     <tbody>
       <% @episodes.each do |episode| %>
         <tr>
@@ -47,11 +43,10 @@
               </p>
             <% end %><!-- if guest star present-->
           </td>
-
         </tr>
       <% end %>
     </tbody>
   </table>
 </div> <!-- row -->
 <hr>
-<p class="button-main"><%= link_to "Back to #{@series.show_name}", tv_series_path(show_id: @show_id) %></p>
+<p class="button-main"><%= link_to "Back to #{@series.show_name}", tv_series_path(show_id: @series.show_id) %></p>

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -166,23 +166,15 @@ module TmdbHandler
   end
 
   def tmdb_handler_tv_series(show_id)
-    @show_url = "#{BASE_URL}/tv/#{show_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=credits"
-    @show_results = JSON.parse(open(@show_url).read, symbolize_names: true)
-    @series = TVSeries.parse_results(@show_results, show_id)
+    show_url = "#{BASE_URL}/tv/#{show_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=credits"
+    show_results = JSON.parse(open(show_url).read, symbolize_names: true)
+    TVSeries.parse_results(show_results, show_id)
   end
 
   def tmdb_handler_tv_season(show_id, season_number)
-    @season_url = "#{BASE_URL}/tv/#{show_id}/season/#{season_number}?api_key=#{ENV['tmdb_api_key']}&append_to_response=credits"
-    @show_id = show_id
-    @season_results = JSON.parse(open(@season_url).read, symbolize_names: true)
-    tmdb_handler_tv_series(show_id)
-    @episodes = TVSeason.parse_results(@season_results[:episodes])
-    # to display the correct current season number in the view:
-    if season_number == "0"
-      @season_number_display = "Misc/Extras"
-    else
-      @season_number_display = "Season #{season_number}"
-    end
+    season_url = "#{BASE_URL}/tv/#{show_id}/season/#{season_number}?api_key=#{ENV['tmdb_api_key']}&append_to_response=credits"
+    season_results = JSON.parse(open(season_url).read, symbolize_names: true)
+    TVSeason.parse_results(season_results[:episodes])
   end
 
   def tmdb_handler_two_movie_search(movie_one, movie_two)


### PR DESCRIPTION
## Related Issues & PRs
* Follow up to PR https://github.com/mikevallano/tmdb-moviequeue/pull/250
* Precursor to PR #252

## Problems Solved
I discovered while refactoring the `TVSeries` object in #250 that it needed a little bit more work to safely remove all of the instance variables. To keep the scope of that PR focused, I pulled that continued refactoring work out into this PR. 

We've learned that it's much more sustainable maintenance-wise to have our instance variables be as few and as close to the surface as possible. This PR and PR #252 continue the work of pulling instance variables out of the `tmdb_handler` service object methods and centralizing their values under fewer instance variables (ideally a single instance variable) in the corresponding `tmdb_controller`.  

This PR does not change any functionality. It is refactor & cleanup only.