### PR TITLE
Add TV episode show page

### DIFF
--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -90,14 +90,6 @@ class TmdbController < ApplicationController
     @credit = tmdb_handler_actor_credit(credit_id)
   end
 
-  def tv_episode
-    @episode = tmdb_handler_tv_episode(
-      series_id: params[:series_id],
-      season_number: params[:season_number],
-      episode_number: params[:episode_number]
-    )
-  end
-
   def tv_series_search
     query = show_title = params[:show_title] || params[:show_title_header]
     if query.present?
@@ -124,6 +116,22 @@ class TmdbController < ApplicationController
       series: @series,
       show_id: show_id,
       season_number: season_number
+    )
+  end
+
+  def tv_episode
+    show_id = params[:show_id]
+    season_number = params[:season_number]
+    @series = tmdb_handler_tv_series(show_id)
+    @season = tmdb_handler_tv_season(
+      series: @series,
+      show_id: show_id,
+      season_number: season_number
+    )
+    @episode = tmdb_handler_tv_episode(
+      show_id: show_id,
+      season_number: season_number,
+      episode_number: params[:episode_number]
     )
   end
 

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -90,6 +90,14 @@ class TmdbController < ApplicationController
     @credit = tmdb_handler_actor_credit(credit_id)
   end
 
+  def tv_episode
+    @episode = tmdb_handler_tv_episode(
+      series_id: params[:series_id],
+      season_number: params[:season_number],
+      episode_number: params[:episode_number]
+    )
+  end
+
   def tv_series_search
     query = show_title = params[:show_title] || params[:show_title_header]
     if query.present?

--- a/app/models/tv_episode.rb
+++ b/app/models/tv_episode.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TVEpisode
   attr_accessor :episode_id, :episode_number, :name, :air_date, :guest_stars, :season_number, :overview, :still_path
 

--- a/app/views/tmdb/tv_episode.html.erb
+++ b/app/views/tmdb/tv_episode.html.erb
@@ -21,8 +21,8 @@
     <div class="headshot-container">
     <%= headshot_for(actor) %>
       <div class="name-block">
-        <p class="actor"><%= link_to "#{truncate(actor.name, length: 18)}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
-        <p>as <%= truncate(actor.character_name, length: 18) %><p>
+        <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
+        <p>as <%= truncate(actor.character_name, length: 18, escape: false) %><p>
       </div> <!-- name-block -->
     </div> <!-- headshot-container -->
   <% end %>
@@ -31,8 +31,8 @@
       <div class="headshot-container">
       <%= headshot_for(actor) %>
         <div class="name-block">
-          <p class="actor"><%= link_to "#{truncate(actor.name, length: 18)}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
-          <p>as <%= truncate(actor.character_name, length: 18) %><p>
+          <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
+          <p>as <%= truncate(actor.character_name, length: 18, escape: false) %><p>
         </div> <!-- name-block -->
       </div> <!-- headshot-container -->
     <% end %>

--- a/app/views/tmdb/tv_episode.html.erb
+++ b/app/views/tmdb/tv_episode.html.erb
@@ -1,0 +1,40 @@
+<h1><%= link_to "#{@series.show_name}", tv_series_path(show_id: @series.show_id) %> <%= @season.name %></h1>
+<p class="button-main"><%= link_to "Back to #{@series.show_name}", tv_series_path(show_id: @series.show_id) %></p>
+
+<h2><%= @season.name %></h2>
+
+<p><%= image_tag("http://image.tmdb.org/t/p/w185#{episode.still_path}") if episode.still_path.present? %></p>
+
+<p>
+  <%= episode.overview %>
+  <% if episode.air_date.present? %>
+    (Aired on <%= episode.air_date.stamp("01-02-2001") %>)
+  <% end %>
+</p>
+
+<h2><%= @episode.name %> Cast</h2>
+
+<div class="row">
+  <% @episode.cast_members.each do |actor| %>
+    <div class="headshot-container">
+    <%= headshot_for(actor) %>
+      <div class="name-block">
+      <p class="actor"><%= link_to "#{actor.name}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
+        <p>As <%= truncate(actor.character_name, length: 18) %><p>
+      </div> <!-- name-block -->
+    </div> <!-- headshot-container -->
+  <% end %>
+  <% if @episode.guest_stars.present? %>
+    <% @episode.guest_stars.each do |actor| %>
+      <div class="headshot-container">
+      <%= headshot_for(actor) %>
+        <div class="name-block">
+        <p class="actor"><%= link_to "#{actor.name}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
+          <p>As <%= truncate(actor.character_name, length: 18) %><p>
+        </div> <!-- name-block -->
+      </div> <!-- headshot-container -->
+    <% end %>
+  <% end %>
+</div> <!-- row -->
+
+<p class="button-main"><%= link_to "Back to #{@season.name}", tv_season(show_id: @series.show_id, season_number: @season.season_number) %></p>

--- a/app/views/tmdb/tv_episode.html.erb
+++ b/app/views/tmdb/tv_episode.html.erb
@@ -1,26 +1,29 @@
-<h1><%= link_to "#{@series.show_name}", tv_series_path(show_id: @series.show_id) %> <%= @season.name %></h1>
-<p class="button-main"><%= link_to "Back to #{@series.show_name}", tv_series_path(show_id: @series.show_id) %></p>
+<h2>
+  <%= link_to "#{@series.show_name}", tv_series_path(show_id: @series.show_id) %> /
+  <%= link_to "Season #{@season.season_number}", tv_season_path(show_id: @series.show_id, season_number: @season.season_number, show_name: @series.show_name) %> /
+  Episode <%= @episode.episode_number %>
+</h2>
 
-<h2><%= @season.name %></h2>
+<div>
+  <h1><%= @episode.name %></h1>
+  <%= image_tag("http://image.tmdb.org/t/p/w185#{@episode.still_path}", class: 'pull-left', style: 'padding-right: 20px;') if @episode.still_path.present? %>
+  <p>
+    <%= @episode.overview %>
+    <% if @episode.air_date.present? %>
+      Aired on <%= @episode.air_date.stamp("01-02-2001") %>
+    <% end %>
+  </p>
+</div>
 
-<p><%= image_tag("http://image.tmdb.org/t/p/w185#{episode.still_path}") if episode.still_path.present? %></p>
 
-<p>
-  <%= episode.overview %>
-  <% if episode.air_date.present? %>
-    (Aired on <%= episode.air_date.stamp("01-02-2001") %>)
-  <% end %>
-</p>
-
-<h2><%= @episode.name %> Cast</h2>
-
-<div class="row">
-  <% @episode.cast_members.each do |actor| %>
+<div class="row", style="clear: both;">
+  <h2>Cast</h2>
+  <% @season.cast_members.each do |actor| %>
     <div class="headshot-container">
     <%= headshot_for(actor) %>
       <div class="name-block">
-      <p class="actor"><%= link_to "#{actor.name}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
-        <p>As <%= truncate(actor.character_name, length: 18) %><p>
+        <p class="actor"><%= link_to "#{truncate(actor.name, length: 18)}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
+        <p>as <%= truncate(actor.character_name, length: 18) %><p>
       </div> <!-- name-block -->
     </div> <!-- headshot-container -->
   <% end %>
@@ -29,12 +32,10 @@
       <div class="headshot-container">
       <%= headshot_for(actor) %>
         <div class="name-block">
-        <p class="actor"><%= link_to "#{actor.name}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
-          <p>As <%= truncate(actor.character_name, length: 18) %><p>
+          <p class="actor"><%= link_to "#{truncate(actor.name, length: 18)}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
+          <p>as <%= truncate(actor.character_name, length: 18) %><p>
         </div> <!-- name-block -->
       </div> <!-- headshot-container -->
     <% end %>
   <% end %>
 </div> <!-- row -->
-
-<p class="button-main"><%= link_to "Back to #{@season.name}", tv_season(show_id: @series.show_id, season_number: @season.season_number) %></p>

--- a/app/views/tmdb/tv_episode.html.erb
+++ b/app/views/tmdb/tv_episode.html.erb
@@ -15,7 +15,6 @@
   </p>
 </div>
 
-
 <div class="row", style="clear: both;">
   <h2>Cast</h2>
   <% @season.cast_members.each do |actor| %>

--- a/app/views/tmdb/tv_season.html.erb
+++ b/app/views/tmdb/tv_season.html.erb
@@ -14,8 +14,8 @@
         <div class="headshot-container">
           <%= headshot_for(actor) %>
           <div class="name-block">
-            <p class="actor"><%= link_to "#{actor.name}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
-            <p>as <%= truncate(actor.character_name, length: 18) %><p>
+            <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
+            <p>as <%= truncate(actor.character_name, length: 18, truncate: false, escape: false) %><p>
           </div> <!-- name-block -->
         </div> <!-- headshot-container -->
       <% end %><!-- actors each do -->

--- a/app/views/tmdb/tv_season.html.erb
+++ b/app/views/tmdb/tv_season.html.erb
@@ -3,7 +3,6 @@
 </h2>
 
 <div>
-  <h1><%= @season.name %></h1>
   <%= image_tag "http://image.tmdb.org/t/p/w185#{@season.poster_path}", class: 'pull-left', style: 'padding-right: 20px;' if @season.poster_path.present? %>
   <p><%= @season.overview %></p>
 </div>

--- a/app/views/tmdb/tv_season.html.erb
+++ b/app/views/tmdb/tv_season.html.erb
@@ -29,7 +29,13 @@
 <h2><%= @season.name %> Episodes</h2>
 <% @season.episodes.each do |episode| %>
   <div class='row'>
-    <h2><%= episode.episode_number %>: <%= episode.name %></h2>
+    <h2>
+      <%= link_to "#{episode.episode_number}. #{episode.name}",
+        tv_episode_path(
+          season_number: @season.season_number,
+          series_id: @series.show_id,
+          episode_number: episode.episode_number) %>
+    </h2>
     <div class='col-sm-6'>
       <p><%= image_tag("http://image.tmdb.org/t/p/w185#{episode.still_path}") if episode.still_path.present? %></p>
       <p>

--- a/app/views/tmdb/tv_season.html.erb
+++ b/app/views/tmdb/tv_season.html.erb
@@ -15,7 +15,7 @@
           <%= headshot_for(actor) %>
           <div class="name-block">
             <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
-            <p>as <%= truncate(actor.character_name, length: 18, truncate: false, escape: false) %><p>
+            <p>as <%= truncate(actor.character_name, length: 18, escape: false) %><p>
           </div> <!-- name-block -->
         </div> <!-- headshot-container -->
       <% end %><!-- actors each do -->

--- a/app/views/tmdb/tv_season.html.erb
+++ b/app/views/tmdb/tv_season.html.erb
@@ -1,15 +1,14 @@
-<h1><%= link_to "#{@series.show_name}", tv_series_path(show_id: @series.show_id) %> <%= @season.name %></h1>
-<p class="button-main"><%= link_to "Back to #{@series.show_name}", tv_series_path(show_id: @series.show_id) %></p>
+<h2>
+  <%= link_to "#{@series.show_name}", tv_series_path(show_id: @series.show_id) %> / <%= @season.name %>
+</h2>
 
-<div class="row">
-  <h2>Seasons: |
-    <% @series.seasons.each do |season| %>
-     <%= link_to season_number_display(season), tv_season_path(show_id: @series.show_id, season_number: season, show_name: @series.show_name) %> |
-    <% end %>
-  </h2>
-</div> <!-- row -->
+<div>
+  <h1><%= @season.name %></h1>
+  <%= image_tag "http://image.tmdb.org/t/p/w185#{@season.poster_path}", class: 'pull-left', style: 'padding-right: 20px;' if @season.poster_path.present? %>
+  <p><%= @season.overview %></p>
+</div>
 
-<div class="row">
+<div class="row", style="clear: both;">
   <% if @season.cast_members.present? %>
     <h2><%= @season.name %> Cast</h2>
       <% @season.cast_members.each do |actor| %>
@@ -17,7 +16,7 @@
           <%= headshot_for(actor) %>
           <div class="name-block">
             <p class="actor"><%= link_to "#{actor.name}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
-            <p>As <%= truncate(actor.character_name, length: 18) %><p>
+            <p>as <%= truncate(actor.character_name, length: 18) %><p>
           </div> <!-- name-block -->
         </div> <!-- headshot-container -->
       <% end %><!-- actors each do -->
@@ -32,8 +31,8 @@
     <h2>
       <%= link_to "#{episode.episode_number}. #{episode.name}",
         tv_episode_path(
+          show_id: @series.show_id,
           season_number: @season.season_number,
-          series_id: @series.show_id,
           episode_number: episode.episode_number) %>
     </h2>
     <div class='col-sm-6'>
@@ -61,5 +60,3 @@
   </div>
   <hr>
 <% end %>
-
-<p class="button-main"><%= link_to "Back to #{@series.show_name}", tv_series_path(show_id: @series.show_id) %></p>

--- a/app/views/tmdb/tv_series.html.erb
+++ b/app/views/tmdb/tv_series.html.erb
@@ -26,8 +26,8 @@
           <div class="headshot-container">
           <%= headshot_for(actor) %>
             <div class="name-block">
-            <p class="actor"><%= link_to "#{actor.name}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
-              <p>As <%= truncate(actor.character_name, length: 18) %><p>
+            <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}")) %></p>
+              <p>as <%= truncate(actor.character_name, length: 18, escape: false) %><p>
             </div> <!-- name-block -->
           </div> <!-- headshot-container -->
           <% end %><!-- actors each do -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  root 'pages#home'
 
   devise_for :users, :controllers => {:registrations => "registrations"}
 
@@ -38,6 +39,7 @@ Rails.application.routes.draw do
   get 'tmdb/actor_credit', to: 'tmdb#actor_credit', as: :actor_credit
   get 'tmdb/two_actor_search', to: 'tmdb#two_actor_search', as: :two_actor_search
   get 'tmdb/director_search', to: 'tmdb#director_search', as: :director_search
+  get 'tmdb/tv_episode', to: 'tmdb#tv_episode', as: :tv_episode
   get 'tmdb/tv_series', to: 'tmdb#tv_series', as: :tv_series
   get 'tmdb/tv_series_search', to: 'tmdb#tv_series_search', as: :tv_series_search
   get 'tmdb/tv_season', to: 'tmdb#tv_season', as: :tv_season
@@ -49,10 +51,8 @@ Rails.application.routes.draw do
 
   resources :invites, only: [:create]
 
-  root 'pages#home'
   get 'about', to: 'pages#about', as: :about
   get 'faq', to: 'pages#faq', as: :faq
   get 'pages/awaiting_confirmation', as: :awaiting_confirmation
   get 'demo', to: 'pages#demo', as: :demo
-
 end

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -181,6 +181,18 @@ module TmdbHandler
     )
   end
 
+  def tmdb_handler_tv_episode(series_id:, season_number:, episode_number:)
+    # https://api.themoviedb.org/3/tv/{tv_id}/season/{season_number}/episode/{episode_number}?api_key=3fb5f9a5dbd80d943fdccf6bd1e7f188&language=en-US
+
+    episode_url = "#{BASE_URL}/tv/#{series_id}/season/#{season_number}/episode/#{episode_number}?api_key=#{ENV['tmdb_api_key']}"
+    episode_data = JSON.parse(open(episode_url).read, symbolize_names: true)
+    TVSeason.parse_record(
+      series: series,
+      show_id: show_id,
+      episode_data: episode_data
+    )
+  end
+
   def tmdb_handler_two_movie_search(movie_one, movie_two)
     tmdb_handler_search(movie_one)
       if @movies.present?

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -181,16 +181,12 @@ module TmdbHandler
     )
   end
 
-  def tmdb_handler_tv_episode(series_id:, season_number:, episode_number:)
+  def tmdb_handler_tv_episode(show_id:, season_number:, episode_number:)
     # https://api.themoviedb.org/3/tv/{tv_id}/season/{season_number}/episode/{episode_number}?api_key=3fb5f9a5dbd80d943fdccf6bd1e7f188&language=en-US
 
-    episode_url = "#{BASE_URL}/tv/#{series_id}/season/#{season_number}/episode/#{episode_number}?api_key=#{ENV['tmdb_api_key']}"
+    episode_url = "#{BASE_URL}/tv/#{show_id}/season/#{season_number}/episode/#{episode_number}?api_key=#{ENV['tmdb_api_key']}"
     episode_data = JSON.parse(open(episode_url).read, symbolize_names: true)
-    TVSeason.parse_record(
-      series: series,
-      show_id: show_id,
-      episode_data: episode_data
-    )
+    TVEpisode.parse_record(episode_data)
   end
 
   def tmdb_handler_two_movie_search(movie_one, movie_two)

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -182,8 +182,6 @@ module TmdbHandler
   end
 
   def tmdb_handler_tv_episode(show_id:, season_number:, episode_number:)
-    # https://api.themoviedb.org/3/tv/{tv_id}/season/{season_number}/episode/{episode_number}?api_key=3fb5f9a5dbd80d943fdccf6bd1e7f188&language=en-US
-
     episode_url = "#{BASE_URL}/tv/#{show_id}/season/#{season_number}/episode/#{episode_number}?api_key=#{ENV['tmdb_api_key']}"
     episode_data = JSON.parse(open(episode_url).read, symbolize_names: true)
     TVEpisode.parse_record(episode_data)


### PR DESCRIPTION
## Related Issues & PRs
* Follow up to PR https://github.com/mikevallano/tmdb-moviequeue/pull/253

## What This PR does
* Adds a 🔥 new page for episodes
* Allows us to see profile pics for all guest starts in addition to season cast
* Updates linking on related pages
* Adds overviews on related pages

## Screenshots
Before: no season overview. No link to episode page.
<img width="371" alt="Screen Shot 2021-12-26 at 2 19 55 PM" src="https://user-images.githubusercontent.com/8680712/147419216-20285478-2a4a-404e-937f-65bc853b579a.png">

After: Season page includes season poster, overview, and links to episode pages.
<img width="371" alt="Screen Shot 2021-12-26 at 2 19 03 PM" src="https://user-images.githubusercontent.com/8680712/147419202-bcf15fc4-27e6-48ce-91ad-e33248dd8402.png">

Hey look! Episode page! It includes season cast as well as guest stars.
<img width="371" alt="Screen Shot 2021-12-26 at 2 19 20 PM" src="https://user-images.githubusercontent.com/8680712/147419207-7061c1d0-e639-4165-9f1f-bd37123a1cd4.png">

## Things Learned
* It feels a bit costly to have to hit 3 endpoints for a show page, but we're not storing the parent data anywhere, so I'm not sure how to do it more efficiently just yet.
* We can consider this version the first iteration and then get clever about how to make it mo'bettah.
