### PR TITLE
Add actor age to movies credits on bio page

### DIFF
--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -7,6 +7,11 @@ module MoviesHelper
     end
   end
 
+  def actor_age_at_movie_release(actor_birthday, release_year)
+    birth_year = actor_birthday.to_date.year
+    release_year.to_i - birth_year
+  end
+
   def link_to_movie(movie)
     if movie.in_db
       movie_path(movie)

--- a/app/views/tmdb/_movie_credits.html.erb
+++ b/app/views/tmdb/_movie_credits.html.erb
@@ -4,8 +4,11 @@
 </h3>
 <ul>
   <% @person_movie_credits.actor.each do |credit| %>
-    <li><%= link_to credit.title, movie_more_path(tmdb_id: "#{credit.tmdb_id}") %>
-    <%= " | #{credit.date} " if credit.date != "Date unavailable" %>
-    <%= "| As #{credit.character}" if credit.character.present? %></li>
+    <li>
+      <%= link_to credit.title, movie_more_path(tmdb_id: "#{credit.tmdb_id}") %>
+      <%= "| #{credit.date}" if credit.date != "Date unavailable" %>
+      <%= "| age #{actor_age_at_movie_release(@person_profile.birthday, credit.date)}" if credit.date != "Date unavailable" %>
+      <%= "as #{credit.character}" if credit.character.present? %>
+  </li>
   <% end %>
 </ul>

--- a/app/views/tmdb/_tv_credits.html.erb
+++ b/app/views/tmdb/_tv_credits.html.erb
@@ -2,7 +2,7 @@
 <ul>
   <% @person_tv_credits.actor.each do |credit| %>
     <li><%= link_to "#{credit.show_name}", tv_series_path(show_id: credit.show_id, actor_id: @actor_id) %>
-    <%= "| As #{credit.character}" if credit.character.present? %> |
+    <%= "| as #{credit.character}" if credit.character.present? %> |
     <%= link_to " Appearance Details", actor_credit_path(actor_id: @actor_id, credit_id: credit.credit_id,
     show_name: "#{credit.show_name}"), id: "appearance_details_#{credit.show_name.downcase}" %></li>
   <% end %>

--- a/spec/helpers/movies_helper_spec.rb
+++ b/spec/helpers/movies_helper_spec.rb
@@ -22,6 +22,16 @@ describe MoviesHelper, type: :helper do
     end
   end
 
+  describe 'actor_age_at_movie_release' do
+    it "returns an actor's age at the time" do
+      actor_birthday = '2000-01-31'
+      movie_release_year = '2020'
+      age = actor_age_at_movie_release(actor_birthday, movie_release_year)
+
+      expect(age).to eq(20)
+    end
+  end
+
   describe '#link_to_movie' do
     it 'returns the correct link path when movie is not in db' do
       allow(movie).to receive(:in_db).and_return(false)


### PR DESCRIPTION
## Related Issues & PRs
* Partially addresses Issue https://github.com/mikevallano/tmdb-moviequeue/issues/249

## Problems Solved
* I'm always curious how old an actor is when they're in a movie
* I don't like doing math
* Only displays if there is enough information to do the math
* I'd like this info to be on the movie cast page, but we've got some n+1 issues. This is a compromise.

## Screenshots
Before: how in the heck old is Tommy Lee Jones in these movies??
<img width="594" alt="Screen Shot 2021-12-24 at 10 48 06 AM" src="https://user-images.githubusercontent.com/8680712/147365428-5c983280-e6fd-45a3-81c0-b09821a273e6.png">

After: oh, okay. Has he _always_ been in his 70s??
<img width="586" alt="Screen Shot 2021-12-24 at 10 49 39 AM" src="https://user-images.githubusercontent.com/8680712/147365481-fab711ed-7867-4806-9bac-b9b984bdc53c.png">

No, actually, he was in his 40s once. But how old was he in the MIBs?
<img width="468" alt="Screen Shot 2021-12-24 at 10 52 59 AM" src="https://user-images.githubusercontent.com/8680712/147365609-b0bc46ec-8f02-4571-91aa-c99f745fabb9.png">

Oh, okay.
<img width="521" alt="Screen Shot 2021-12-24 at 10 53 47 AM" src="https://user-images.githubusercontent.com/8680712/147365660-a50b7f9e-a0e6-43b0-ac25-7ef0d9ba1ac4.png">


