### PR TITLE
Resolve bug where age is not able to be calculated

### DIFF
--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -7,7 +7,14 @@ module MoviesHelper
     end
   end
 
+  def display_actor_age_at_release(actor_birthday, release_year)
+    age = actor_age_at_movie_release(actor_birthday, release_year)
+    "| age #{age}" if age.present?
+  end
+
   def actor_age_at_movie_release(actor_birthday, release_year)
+    return nil unless actor_birthday.to_date.present? && release_year != "Date unavailable"
+
     birth_year = actor_birthday.to_date.year
     release_year.to_i - birth_year
   end

--- a/app/views/tmdb/_movie_credits.html.erb
+++ b/app/views/tmdb/_movie_credits.html.erb
@@ -7,7 +7,7 @@
     <li>
       <%= link_to credit.title, movie_more_path(tmdb_id: "#{credit.tmdb_id}") %>
       <%= "| #{credit.date}" if credit.date != "Date unavailable" %>
-      <%= "| age #{actor_age_at_movie_release(@person_profile.birthday, credit.date)}" if credit.date != "Date unavailable" %>
+      <%= display_actor_age_at_release(@person_profile.birthday, credit.date) %>
       <%= "as #{credit.character}" if credit.character.present? %>
   </li>
   <% end %>

--- a/spec/helpers/movies_helper_spec.rb
+++ b/spec/helpers/movies_helper_spec.rb
@@ -22,6 +22,20 @@ describe MoviesHelper, type: :helper do
     end
   end
 
+  describe 'display_actor_age_at_release' do
+    it 'does not display anything if the age is unavailable' do
+      allow_any_instance_of(MoviesHelper).to receive(:actor_age_at_movie_release).and_return(nil)
+      result = display_actor_age_at_release('foo', 'bar')
+      expect(result).to eq(nil)
+    end
+
+    it 'displays "| age 10" if the age is available' do
+      allow_any_instance_of(MoviesHelper).to receive(:actor_age_at_movie_release).and_return(10)
+      result = display_actor_age_at_release('foo', 'bar')
+      expect(result).to eq("| age 10")
+    end
+  end
+
   describe 'actor_age_at_movie_release' do
     it "returns an actor's age at the time" do
       actor_birthday = '2000-01-31'
@@ -29,6 +43,22 @@ describe MoviesHelper, type: :helper do
       age = actor_age_at_movie_release(actor_birthday, movie_release_year)
 
       expect(age).to eq(20)
+    end
+
+    it 'returns nil when a birth year is missing' do
+      actor_birthday = ''
+      movie_release_year = '2020'
+      age = actor_age_at_movie_release(actor_birthday, movie_release_year)
+
+      expect(age).to be(nil)
+    end
+
+    it 'returns nil when a release date is unavailable' do
+      actor_birthday = '2000-01-31'
+      movie_release_year = 'Date unavailable'
+      age = actor_age_at_movie_release(actor_birthday, movie_release_year)
+
+      expect(age).to be(nil)
     end
   end
 


### PR DESCRIPTION
## Related Issues & PRs
Closes #258

## Problems Solved
* handles when an actor's age can't be calculated
* displays no age information if we don't have an age
* displays `| age 42` when an actor's age is 42

## Screenshots
Here's our main culprit: the actor without a birth year. Now you can see it doesn't say a peep about age.
<img width="586" alt="Screen Shot 2021-12-30 at 4 00 25 PM" src="https://user-images.githubusercontent.com/8680712/147790763-18f93e16-b83d-4e88-bcd4-2b0c36374b38.png">

Here's an example where the first line doesn't know about age for some reason, but subsequent lines do:
<img width="586" alt="Screen Shot 2021-12-30 at 4 00 38 PM" src="https://user-images.githubusercontent.com/8680712/147790793-ff6e4648-70ba-4541-8f9f-892baa6aacfe.png">


## Things Learned
* Conditions are annoying
* I had a choice of putting more conditional logic in the erb or moving it into a new helper method. I chose the latter.
