### PR TITLE
Rename tmdb_handler_ methods as class-level

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -8,7 +8,7 @@ class ListingsController < ApplicationController
     @tmdb_id = params[:tmdb_id]
 
     unless Movie.exists?(tmdb_id: @tmdb_id)
-      tmdb_handler_add_movie(@tmdb_id)
+      TmdbHandler.add_movie(@tmdb_id)
     end
 
     @movie = Movie.find_by_tmdb_id(@tmdb_id)

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -50,7 +50,7 @@ class MoviesController < ApplicationController
     if Movie.exists?(tmdb_id: @tmdb_id)
       @movie = Movie.find_by(tmdb_id: @tmdb_id)
     else
-      tmdb_handler_movie_more(@tmdb_id)
+      TmdbHandler.movie_more(@tmdb_id)
     end
     respond_to :js
   end
@@ -60,7 +60,7 @@ class MoviesController < ApplicationController
     if Movie.exists?(tmdb_id: @tmdb_id)
       @movie = Movie.find_by(tmdb_id: @tmdb_id)
     else
-      tmdb_handler_movie_more(@tmdb_id)
+      TmdbHandler.movie_more(@tmdb_id)
     end
     respond_to :js
   end
@@ -71,7 +71,7 @@ class MoviesController < ApplicationController
     if params[:tmdb_id].present?
       @tmdb_id = params[:tmdb_id]
       unless Movie.exists?(tmdb_id: @tmdb_id)
-        tmdb_handler_add_movie(@tmdb_id)
+        TmdbHandler.add_movie(@tmdb_id)
       end
         @movie = Movie.find_by(tmdb_id: @tmdb_id)
       else

--- a/app/controllers/screenings_controller.rb
+++ b/app/controllers/screenings_controller.rb
@@ -72,7 +72,7 @@ class ScreeningsController < ApplicationController
       if params[:tmdb_id].present?
         @tmdb_id = params[:tmdb_id]
         unless Movie.exists?(tmdb_id: @tmdb_id)
-          tmdb_handler_add_movie(@tmdb_id)
+          TmdbHandler.add_movie(@tmdb_id)
         end
         @movie = Movie.find_by(tmdb_id: @tmdb_id)
       else

--- a/app/controllers/taggings_controller.rb
+++ b/app/controllers/taggings_controller.rb
@@ -38,7 +38,7 @@ private
     if params[:tmdb_id].present?
       @tmdb_id = params[:tmdb_id]
       unless Movie.exists?(tmdb_id: @tmdb_id)
-        tmdb_handler_add_movie(@tmdb_id)
+        TmdbHandler.add_movie(@tmdb_id)
       end
         @movie = Movie.find_by(tmdb_id: @tmdb_id)
       else

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -34,7 +34,7 @@ class TmdbController < ApplicationController
     if params[:tmdb_id]
       @tmdb_id = params[:tmdb_id]
       movie = Movie.find_by!(tmdb_id: @tmdb_id)
-      TmdbHandler.TmdbHandler.update_movie(movie)
+      TmdbHandler.update_movie(movie)
     end
     redirect_to movie_more_path(tmdb_id: @tmdb_id)
   end

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -1,31 +1,30 @@
 class TmdbController < ApplicationController
-  before_action :authenticate_user!
-
   require 'open-uri'
-  include TmdbHandler
   include SearchParamParser
+
+  before_action :authenticate_user!
 
   def search
     if @movie_title = params[:movie_title] || params[:movie_title_header]
       @movie_title = I18n.transliterate(@movie_title)
-      tmdb_handler_search(@movie_title)
+      TmdbHandler.search(@movie_title)
     end
   end
 
   def movie_autocomplete
-    tmdb_handler_movie_autocomplete(params[:term])
+    TmdbHandler.movie_autocomplete(params[:term])
     render json: @autocomplete_results
   end
 
   def person_autocomplete
-    tmdb_handler_person_autocomplete(params[:term])
+    TmdbHandler.person_autocomplete(params[:term])
     render json: @autocomplete_results
   end
 
   def movie_more
     if params[:tmdb_id]
       @tmdb_id = params[:tmdb_id]
-      tmdb_handler_movie_more(@tmdb_id)
+      TmdbHandler.movie_more(@tmdb_id)
     else
       redirect_to api_search_path
     end
@@ -35,7 +34,7 @@ class TmdbController < ApplicationController
     if params[:tmdb_id]
       @tmdb_id = params[:tmdb_id]
       movie = Movie.find_by!(tmdb_id: @tmdb_id)
-      TmdbHandler.tmdb_handler_update_movie(movie)
+      TmdbHandler.TmdbHandler.update_movie(movie)
     end
     redirect_to movie_more_path(tmdb_id: @tmdb_id)
   end
@@ -48,16 +47,16 @@ class TmdbController < ApplicationController
       else
         @page = 1
       end #if page
-      tmdb_handler_similar_movies(@tmdb_id, @page)
+      TmdbHandler.similar_movies(@tmdb_id, @page)
     end #if tmdb_id
-  end #similar movies
+  end
 
   def full_cast
     if params[:tmdb_id]
       @tmdb_id = params[:tmdb_id]
-      tmdb_handler_full_cast(@tmdb_id)
+      TmdbHandler.full_cast(@tmdb_id)
     end
-  end #full cast
+  end
 
   def actor_search
     if params[:actor]
@@ -65,7 +64,7 @@ class TmdbController < ApplicationController
       params[:page] = params[:page] || 1
       params[:sort_by] = params[:sort_by] || "popularity"
 
-      tmdb_handler_discover_search(params)
+      TmdbHandler.discover_search(params)
     end
   end
 
@@ -76,43 +75,43 @@ class TmdbController < ApplicationController
       params[:page] = params[:page] || 1
       params[:sort_by] = params[:sort_by] || "popularity"
 
-      tmdb_handler_discover_search(params)
+      TmdbHandler.discover_search(params)
     end
   end
 
   def actor_more
     @actor_id = params[:actor_id]
-    tmdb_handler_actor_more(@actor_id)
+    TmdbHandler.actor_more(@actor_id)
   end
 
   def actor_credit
     credit_id = params[:credit_id]
-    @credit = tmdb_handler_actor_credit(credit_id)
+    @credit = TmdbHandler.actor_credit(credit_id)
   end
 
   def tv_series_search
     query = show_title = params[:show_title] || params[:show_title_header]
     if query.present?
       @query = I18n.transliterate(query)
-      @search_results = tmdb_handler_tv_series_search(query)
+      @search_results = TmdbHandler.tv_series_search(query)
     end
   end
 
   def tv_series_autocomplete
-    autocomplete_results = tmdb_handler_tv_series_autocomplete(params[:term])
+    autocomplete_results = TmdbHandler.tv_series_autocomplete(params[:term])
     render json: autocomplete_results
   end
 
   def tv_series
     show_id = params[:show_id]
-    @series = tmdb_handler_tv_series(show_id)
+    @series = TmdbHandler.tv_series(show_id)
   end
 
   def tv_season
     show_id = params[:show_id]
     season_number = params[:season_number]
-    @series = tmdb_handler_tv_series(show_id)
-    @season = tmdb_handler_tv_season(
+    @series = TmdbHandler.tv_series(show_id)
+    @season = TmdbHandler.tv_season(
       series: @series,
       show_id: show_id,
       season_number: season_number
@@ -122,13 +121,13 @@ class TmdbController < ApplicationController
   def tv_episode
     show_id = params[:show_id]
     season_number = params[:season_number]
-    @series = tmdb_handler_tv_series(show_id)
-    @season = tmdb_handler_tv_season(
+    @series = TmdbHandler.tv_series(show_id)
+    @season = TmdbHandler.tv_season(
       series: @series,
       show_id: show_id,
       season_number: season_number
     )
-    @episode = tmdb_handler_tv_episode(
+    @episode = TmdbHandler.tv_episode(
       show_id: show_id,
       season_number: season_number,
       episode_number: params[:episode_number]
@@ -139,7 +138,7 @@ class TmdbController < ApplicationController
     if params[:movie_one] && params[:movie_two]
       @movie_one = params[:movie_one]
       @movie_two = params[:movie_two]
-      tmdb_handler_two_movie_search(@movie_one, @movie_two)
+      TmdbHandler.two_movie_search(@movie_one, @movie_two)
     end
   end
 
@@ -147,7 +146,7 @@ class TmdbController < ApplicationController
     if params[:director_id]
       @director_id = params[:director_id]
       @name = params[:name]
-      tmdb_handler_person_detail_search(@director_id)
+      TmdbHandler.person_detail_search(@director_id)
     end
   end
 
@@ -165,10 +164,9 @@ class TmdbController < ApplicationController
       @discover_view_params = @passed_params.slice(:actor, :genre, :date, :year, :year_select, :mpaa_rating, :sort_by)
       @params_for_view = discover_show_search_params(@discover_view_params)
 
-      tmdb_handler_discover_search(@passed_params)
+      TmdbHandler.discover_search(@passed_params)
     end
-
-  end #discover search
+  end
 
   def discover_show_search_params(show_params)
     @keys = show_params.keys
@@ -200,5 +198,4 @@ class TmdbController < ApplicationController
     end
     "#{@actor_display} #{@genre_display} #{@rating_display} #{@year_display} #{@sort_display}"
   end
-
-end #final
+end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -16,7 +16,7 @@ namespace :tmdb_data do
     updated_movies = []
 
     movies.each do |movie|
-      TmdbHandler.tmdb_handler_update_movie(movie)
+      TmdbHandler.update_movie(movie)
       puts "Movie refreshed. #{movie.title}. tmdb_id: #{movie.tmdb_id}"
       updated_movies << movie.tmdb_id
       sleep 0.01

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -87,7 +87,7 @@ module TmdbHandler
     popularity: @movie.popularity, runtime: @movie.runtime, mpaa_rating: @movie.mpaa_rating)
   end
 
-  def self.self.update_movie(movie)
+  def self.update_movie(movie)
     tmdb_id = movie.tmdb_id.to_s
     movie_url = "#{BASE_URL}/movie/#{tmdb_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=trailers,credits,similar,releases"
     api_result = HTTParty.get(movie_url).deep_symbolize_keys rescue nil

--- a/spec/modules/tmdb_handler_spec.rb
+++ b/spec/modules/tmdb_handler_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe TmdbHandler, type: :module do
 
   context 'with a valid movie' do
     it 'returns true' do
-      VCR.use_cassette('TmdbHandler.update_movie_with_a_valid_movie') do
+      VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie') do
         expect(subject).to eq(true)
       end
     end
 
     it 'updates the movie' do
-      VCR.use_cassette('TmdbHandler.update_movie_with_a_valid_movie') do
+      VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie') do
         expect{ subject }.to change{ movie.reload.updated_at }
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe TmdbHandler, type: :module do
   context 'when no movie found from api response' do
     before { movie.update(tmdb_id: 'wrong')}
     it 'raises an error and does not update the movie' do
-      VCR.use_cassette('TmdbHandler.update_movie_with_an_invalid_movie') do
+      VCR.use_cassette('tmdb_handler_update_movie_with_an_invalid_movie') do
         expect{ subject }.not_to raise_error(TmdbHandler::TmdbHandlerError)
         expect{ subject }.not_to change{ movie.reload.updated_at }
       end
@@ -32,13 +32,13 @@ RSpec.describe TmdbHandler, type: :module do
   context 'when the title does not match' do
     before { movie.update(title: 'Fargowrong') }
     it 'does not raise an error' do
-      VCR.use_cassette('TmdbHandler.update_movie_with_wrong_title') do
+      VCR.use_cassette('tmdb_handler_update_movie_with_wrong_title') do
         expect{subject}.not_to raise_error
       end
     end
 
     it 'still updates the movie' do
-      VCR.use_cassette('TmdbHandler.update_movie_with_wrong_title') do
+      VCR.use_cassette('tmdb_handler_update_movie_with_wrong_title') do
         expect{ subject }.to change{ movie.reload.updated_at }
       end
     end
@@ -49,7 +49,7 @@ RSpec.describe TmdbHandler, type: :module do
     let(:correct_mpaa_rating) { 'R' }
     before { movie.update(mpaa_rating: wrong_mpaa_rating) }
     it 'updates movie with latest tmdb info' do
-      VCR.use_cassette('TmdbHandler.update_movie_with_outdated_info') do
+      VCR.use_cassette('tmdb_handler_update_movie_with_outdated_info') do
         subject
         expect(movie.reload.mpaa_rating).to eq(correct_mpaa_rating)
       end
@@ -61,7 +61,7 @@ RSpec.describe TmdbHandler, type: :module do
     before { dupe_movie.save(validate: false) }
 
     it 'raises an error and does not update the movie' do
-      VCR.use_cassette('TmdbHandler.update_movie_with_a_valid_movie') do
+      VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie') do
         expect{subject}.to raise_error(TmdbHandler::TmdbHandlerError).and not_change{ movie.reload.updated_at }
       end
     end

--- a/spec/modules/tmdb_handler_spec.rb
+++ b/spec/modules/tmdb_handler_spec.rb
@@ -3,17 +3,17 @@ require 'rails_helper'
 RSpec.describe TmdbHandler, type: :module do
   let(:movie) { create(:movie_in_tmdb) }
   let(:tmdb_id) { movie.tmdb_id }
-  subject { TmdbHandler.tmdb_handler_update_movie(movie) }
+  subject { TmdbHandler.update_movie(movie) }
 
   context 'with a valid movie' do
     it 'returns true' do
-      VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie') do
+      VCR.use_cassette('TmdbHandler.update_movie_with_a_valid_movie') do
         expect(subject).to eq(true)
       end
     end
 
     it 'updates the movie' do
-      VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie') do
+      VCR.use_cassette('TmdbHandler.update_movie_with_a_valid_movie') do
         expect{ subject }.to change{ movie.reload.updated_at }
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe TmdbHandler, type: :module do
   context 'when no movie found from api response' do
     before { movie.update(tmdb_id: 'wrong')}
     it 'raises an error and does not update the movie' do
-      VCR.use_cassette('tmdb_handler_update_movie_with_an_invalid_movie') do
+      VCR.use_cassette('TmdbHandler.update_movie_with_an_invalid_movie') do
         expect{ subject }.not_to raise_error(TmdbHandler::TmdbHandlerError)
         expect{ subject }.not_to change{ movie.reload.updated_at }
       end
@@ -32,13 +32,13 @@ RSpec.describe TmdbHandler, type: :module do
   context 'when the title does not match' do
     before { movie.update(title: 'Fargowrong') }
     it 'does not raise an error' do
-      VCR.use_cassette('tmdb_handler_update_movie_with_wrong_title') do
+      VCR.use_cassette('TmdbHandler.update_movie_with_wrong_title') do
         expect{subject}.not_to raise_error
       end
     end
 
     it 'still updates the movie' do
-      VCR.use_cassette('tmdb_handler_update_movie_with_wrong_title') do
+      VCR.use_cassette('TmdbHandler.update_movie_with_wrong_title') do
         expect{ subject }.to change{ movie.reload.updated_at }
       end
     end
@@ -49,7 +49,7 @@ RSpec.describe TmdbHandler, type: :module do
     let(:correct_mpaa_rating) { 'R' }
     before { movie.update(mpaa_rating: wrong_mpaa_rating) }
     it 'updates movie with latest tmdb info' do
-      VCR.use_cassette('tmdb_handler_update_movie_with_outdated_info') do
+      VCR.use_cassette('TmdbHandler.update_movie_with_outdated_info') do
         subject
         expect(movie.reload.mpaa_rating).to eq(correct_mpaa_rating)
       end
@@ -61,7 +61,7 @@ RSpec.describe TmdbHandler, type: :module do
     before { dupe_movie.save(validate: false) }
 
     it 'raises an error and does not update the movie' do
-      VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie') do
+      VCR.use_cassette('TmdbHandler.update_movie_with_a_valid_movie') do
         expect{subject}.to raise_error(TmdbHandler::TmdbHandlerError).and not_change{ movie.reload.updated_at }
       end
     end


### PR DESCRIPTION
Blocked by #270

## Problems Solved
This is a cleanup PR. It is a simple rename and does not change any functionality. We decided to rename all of the methods in the `TmdbHandler` module to make them more idiomatic by removing `tmdb_handler_` and prepending `self`. We prefer to see the `self.` notation over the `self << class` notation and since we don't have any private methods in this module, it works for now. It's not 100% squeaky clean in scope as I did take some liberties in cleaning up some method-end comments and convert a couple of `if` statements into one-liners.

This sets us up to be able to refactor this module in subsequent PRs, including some things we talked about:
* moving this to a namespace: `Tmdb::Handler` along with `Tmdb::ImageService`
* maybe renaming this to something like `Tmdb::Client` or `Tmdb::Api`
* maybe pulling some logic into private methods