### PR TITLE
Instance variable refactors for director_search and actor_more

### DIFF
--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -148,10 +148,6 @@ class TmdbController < ApplicationController
       @director_id = params[:director_id]
       @name = params[:name]
       @director = tmdb_handler_person_detail_search(@director_id)
-
-      @person_profile = @director.profile
-      @person_movie_credits = @director.movie_credits
-      @person_tv_credits = @director.tv_credits
     end
   end
 

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -82,7 +82,7 @@ class TmdbController < ApplicationController
   end
 
   def actor_more
-    @actor = tmdb_handler_actor_more(params[:actor_id])
+    @actor = tmdb_handler_person_detail_search(params[:actor_id])
   end
 
   def actor_credit
@@ -145,9 +145,7 @@ class TmdbController < ApplicationController
 
   def director_search
     if params[:director_id]
-      @director_id = params[:director_id]
-      @name = params[:name]
-      @director = tmdb_handler_person_detail_search(@director_id)
+      @director = tmdb_handler_person_detail_search(params[:director_id])
     end
   end
 

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -4,7 +4,6 @@ class TmdbController < ApplicationController
   require 'open-uri'
   include TmdbHandler
   include SearchParamParser
-  include TmdbHandler
 
   def search
     if @movie_title = params[:movie_title] || params[:movie_title_header]

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -4,6 +4,7 @@ class TmdbController < ApplicationController
   require 'open-uri'
   include TmdbHandler
   include SearchParamParser
+  include TmdbHandler
 
   def search
     if @movie_title = params[:movie_title] || params[:movie_title_header]
@@ -81,8 +82,7 @@ class TmdbController < ApplicationController
   end
 
   def actor_more
-    @actor_id = params[:actor_id]
-    tmdb_handler_actor_more(@actor_id)
+    @actor = tmdb_handler_actor_more(params[:actor_id])
   end
 
   def actor_credit
@@ -147,7 +147,11 @@ class TmdbController < ApplicationController
     if params[:director_id]
       @director_id = params[:director_id]
       @name = params[:name]
-      tmdb_handler_person_detail_search(@director_id)
+      @director = tmdb_handler_person_detail_search(@director_id)
+
+      @person_profile = @director.profile
+      @person_movie_credits = @director.movie_credits
+      @person_tv_credits = @director.tv_credits
     end
   end
 

--- a/app/views/tmdb/_director_credits.html.erb
+++ b/app/views/tmdb/_director_credits.html.erb
@@ -1,13 +1,13 @@
-<h3>Director Credits (<%= @person_movie_credits.directing.size + @person_tv_credits.directing.size %>)</h3>
-  <p>Movies (<%= @person_movie_credits.directing.size %>) </p>
+<h3>Director Credits (<%= movie_credits.directing.size + tv_credits.directing.size %>)</h3>
+  <p>Movies (<%= movie_credits.directing.size %>) </p>
     <ul>
-      <% @person_movie_credits.directing.each do |credit| %>
+      <% movie_credits.directing.each do |credit| %>
         <%= render "movie_credit_loop", credit: credit %>
       <% end %>
     </ul>
-  <p>TV (<%= @person_tv_credits.directing.size %>)</p>
+  <p>TV (<%= tv_credits.directing.size %>)</p>
     <ul>
-      <% @person_tv_credits.directing.each do |credit| %>
+      <% tv_credits.directing.each do |credit| %>
         <%= render "tv_credit_loop", credit: credit %>
       <% end %>
     </ul>

--- a/app/views/tmdb/_editor_credits.html.erb
+++ b/app/views/tmdb/_editor_credits.html.erb
@@ -1,13 +1,13 @@
-<h3>Editor Credits (<%= @person_movie_credits.editing.size + @person_tv_credits.editing.size %>)</h3>
-  <p>Movies (<%= @person_movie_credits.editing.size %>)</p>
+<h3>Editor Credits (<%= movie_credits.editing.size + tv_credits.editing.size %>)</h3>
+  <p>Movies (<%= movie_credits.editing.size %>)</p>
     <ul>
-      <% @person_movie_credits.editing.each do |credit| %>
+      <% movie_credits.editing.each do |credit| %>
         <%= render "movie_credit_loop", credit: credit %>
       <% end %>
     </ul>
-  <p>TV (<%= @person_tv_credits.editing.size %>)</p>
+  <p>TV (<%= tv_credits.editing.size %>)</p>
     <ul>
-      <% @person_tv_credits.editing.each do |credit| %>
+      <% tv_credits.editing.each do |credit| %>
         <%= render "tv_credit_loop", credit: credit %>
       <% end %>
     </ul>

--- a/app/views/tmdb/_movie_credits.html.erb
+++ b/app/views/tmdb/_movie_credits.html.erb
@@ -1,13 +1,13 @@
 <h3>
-  <%= link_to 'Movie Poster View', actor_movie_posters_uri(@person_profile), style: 'float: right;' %>
-  Movie Credits (<%= @person_movie_credits.actor.size %>)
+  <%= link_to 'Movie Poster View', actor_movie_posters_uri(person_profile), style: 'float: right;' %>
+  Movie Credits (<%= movie_credits.actor.size %>)
 </h3>
 <ul>
-  <% @person_movie_credits.actor.each do |credit| %>
+  <% movie_credits.actor.each do |credit| %>
     <li>
       <%= link_to credit.title, movie_more_path(tmdb_id: "#{credit.tmdb_id}") %>
       <%= "| #{credit.date}" if credit.date != "Date unavailable" %>
-      <%= display_actor_age_at_release(@person_profile.birthday, credit.date) %>
+      <%= display_actor_age_at_release(person_profile.birthday, credit.date) %>
       <%= "as #{credit.character}" if credit.character.present? %>
   </li>
   <% end %>

--- a/app/views/tmdb/_producer_credits.html.erb
+++ b/app/views/tmdb/_producer_credits.html.erb
@@ -1,13 +1,13 @@
-<h3>Producer Credits (<%= @person_movie_credits.producer.size + @person_tv_credits.producer.size  %>)</h3>
-    <p>Movies (<%= @person_movie_credits.producer.size %>) </p>
+<h3>Producer Credits (<%= movie_credits.producer.size + tv_credits.producer.size  %>)</h3>
+    <p>Movies (<%= movie_credits.producer.size %>) </p>
       <ul>
-        <% @person_movie_credits.producer.each do |credit| %>
+        <% movie_credits.producer.each do |credit| %>
           <%= render "movie_credit_loop", credit: credit %>
         <% end %>
       </ul>
-    <p>TV (<%= @person_tv_credits.producer.size %>)</p>
+    <p>TV (<%= tv_credits.producer.size %>)</p>
         <ul>
-          <% @person_tv_credits.producer.each do |credit| %>
+          <% tv_credits.producer.each do |credit| %>
             <%= render "tv_credit_loop", credit: credit %>
           <% end %>
         </ul>

--- a/app/views/tmdb/_screenplay_credits.html.erb
+++ b/app/views/tmdb/_screenplay_credits.html.erb
@@ -1,14 +1,14 @@
-<h3>Screenplay Credits (<%= @person_movie_credits.screenplay.size + @person_tv_credits.screenplay.size %>)</h3>
-  <p>Movies (<%= @person_movie_credits.screenplay.size %>)</p>
+<h3>Screenplay Credits (<%= movie_credits.screenplay.size + tv_credits.screenplay.size %>)</h3>
+  <p>Movies (<%= movie_credits.screenplay.size %>)</p>
     <ul>
-      <% @person_movie_credits.screenplay.each do |credit| %>
+      <% movie_credits.screenplay.each do |credit| %>
         <%= render "movie_credit_loop", credit: credit %>
       <% end %>
     </ul>
 
-  <p>TV (<%= @person_tv_credits.screenplay.size %>)</p>
+  <p>TV (<%= tv_credits.screenplay.size %>)</p>
     <ul>
-      <% @person_tv_credits.writing.each do |credit| %>
+      <% tv_credits.writing.each do |credit| %>
         <%= render "tv_credit_loop", credit: credit %>
       <% end %>
     </ul>

--- a/app/views/tmdb/_tv_credits.html.erb
+++ b/app/views/tmdb/_tv_credits.html.erb
@@ -1,9 +1,9 @@
-<h3>TV Credits (<%= @person_tv_credits.actor.size %>)</h3>
+<h3>TV Credits (<%= tv_credits.actor.size %>)</h3>
 <ul>
-  <% @person_tv_credits.actor.each do |credit| %>
-    <li><%= link_to "#{credit.show_name}", tv_series_path(show_id: credit.show_id, actor_id: @actor_id) %>
+  <% tv_credits.actor.each do |credit| %>
+    <li><%= link_to "#{credit.show_name}", tv_series_path(show_id: credit.show_id, actor_id: actor_id) %>
     <%= "| as #{credit.character}" if credit.character.present? %> |
-    <%= link_to " Appearance Details", actor_credit_path(actor_id: @actor_id, credit_id: credit.credit_id,
+    <%= link_to " Appearance Details", actor_credit_path(actor_id: actor_id, credit_id: credit.credit_id,
     show_name: "#{credit.show_name}"), id: "appearance_details_#{credit.show_name.downcase}" %></li>
   <% end %>
 </ul>

--- a/app/views/tmdb/_writer_credits.html.erb
+++ b/app/views/tmdb/_writer_credits.html.erb
@@ -1,13 +1,13 @@
-<h3>Writer Credits (<%= @person_movie_credits.writing.size + @person_tv_credits.writing.size %>)</h3>
-  <p>Movies (<%= @person_movie_credits.writing.size %>)</p>
+<h3>Writer Credits (<%= movie_credits.writing.size + tv_credits.writing.size %>)</h3>
+  <p>Movies (<%= movie_credits.writing.size %>)</p>
     <ul>
-      <% @person_movie_credits.writing.each do |credit| %>
+      <% movie_credits.writing.each do |credit| %>
         <%= render "movie_credit_loop", credit: credit %>
       <% end %>
     </ul>
-  <p>TV (<%= @person_tv_credits.writing.size %>)</p>
+  <p>TV (<%= tv_credits.writing.size %>)</p>
     <ul>
-      <% @person_tv_credits.writing.each do |credit| %>
+      <% tv_credits.writing.each do |credit| %>
         <%= render "tv_credit_loop", credit: credit %>
       <% end %>
     </ul>

--- a/app/views/tmdb/actor_more.html.erb
+++ b/app/views/tmdb/actor_more.html.erb
@@ -22,8 +22,8 @@
 
       <%= render partial: "editor_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
 
+      <%= render partial: "writer_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
 
-      <%= render "writer_credits" %>
 
       <%= render "screenplay_credits" %>
 

--- a/app/views/tmdb/actor_more.html.erb
+++ b/app/views/tmdb/actor_more.html.erb
@@ -14,10 +14,10 @@
     <div class="credits">
       <%= render partial: "movie_credits", locals: { person_profile: @actor.profile, movie_credits: @actor.movie_credits } %>
 
+      <%= render partial: "tv_credits", locals: { tv_credits: @actor.tv_credits, actor_id: @actor.person_id }  %>
 
-      <%= render partial "tv_credits", locals: { tv_credits: @actor.tv_credits, actor_id: @actor.person_id }  %>
+      <%= render partial: "director_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
 
-      <%= render partial "director_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
 
       <%= render "producer_credits" %>
       <%= render partial: "editor_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>

--- a/app/views/tmdb/actor_more.html.erb
+++ b/app/views/tmdb/actor_more.html.erb
@@ -24,9 +24,7 @@
 
       <%= render partial: "writer_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
 
-
-      <%= render "screenplay_credits" %>
-
-    </div> <!-- credits -->
-  </div> <!-- row -->
+      <%= render partial: "screenplay_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
+    </div>
+  </div>
 </article>

--- a/app/views/tmdb/actor_more.html.erb
+++ b/app/views/tmdb/actor_more.html.erb
@@ -12,8 +12,8 @@
 
   <div class="row">
     <div class="credits">
+      <%= render partial: "movie_credits", locals: { person_profile: @actor.profile, movie_credits: @actor.movie_credits } %>
 
-      <%= render partial: "movie_credits", locals: { person_profile: @actor.profile } %>
 
       <%= render partial "tv_credits", locals: { tv_credits: @actor.tv_credits, actor_id: @actor.person_id }  %>
 

--- a/app/views/tmdb/actor_more.html.erb
+++ b/app/views/tmdb/actor_more.html.erb
@@ -20,8 +20,8 @@
       <%= render partial "director_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
 
       <%= render "producer_credits" %>
+      <%= render partial: "editor_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
 
-      <%= render "editor_credits" %>
 
       <%= render "writer_credits" %>
 

--- a/app/views/tmdb/actor_more.html.erb
+++ b/app/views/tmdb/actor_more.html.erb
@@ -18,8 +18,8 @@
 
       <%= render partial: "director_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
 
+      <%= render partial: "producer_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
 
-      <%= render "producer_credits" %>
       <%= render partial: "editor_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
 
 

--- a/app/views/tmdb/actor_more.html.erb
+++ b/app/views/tmdb/actor_more.html.erb
@@ -1,11 +1,11 @@
 <article id="profile">
   <div class="row">
     <div class="summary-box">
-      <%= image_tag(TmdbImageService.image_url(file_path: @person_profile.profile_path, size: :medium, image_type: :profile)) %>
+      <%= image_tag(TmdbImageService.image_url(file_path: @actor.profile.profile_path, size: :medium, image_type: :profile)) %>
       <div class="contents">
-        <h1><%= @person_profile.name %></h1>
-        <h2>Born: <%= display_birthday_info(@person_profile) %></h2>
-        <p class="bio"><%= @person_profile.bio %></p>
+        <h1><%= @actor.profile.name %></h1>
+        <h2>Born: <%= display_birthday_info(@actor.profile) %></h2>
+        <p class="bio"><%= @actor.profile.bio %></p>
       </div> <!-- contents -->
     </div> <!-- summary-box -->
   </div> <!-- row -->
@@ -13,11 +13,11 @@
   <div class="row">
     <div class="credits">
 
-      <%= render partial: "movie_credits", locals: { person_profile: @person_profile } %>
+      <%= render partial: "movie_credits", locals: { person_profile: @actor.profile } %>
 
-      <%= render "tv_credits" %>
+      <%= render partial "tv_credits", locals: { tv_credits: @actor.tv_credits, actor_id: @actor.person_id }  %>
 
-      <%= render "director_credits" %>
+      <%= render partial "director_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
 
       <%= render "producer_credits" %>
 

--- a/app/views/tmdb/director_search.html.erb
+++ b/app/views/tmdb/director_search.html.erb
@@ -22,8 +22,8 @@
       <%= render "writer_credits" %>
 
       <%= render "screenplay_credits" %>
+      <%= render partial: "movie_credits", locals: { movie_credits: @director.movie_credits, person_profile: @director.profile }  %>
 
-      <%= render "movie_credits" %>
 
       <%= render partial "tv_credits", locals: { tv_credits: @director.tv_credits, actor_id: @director.person_id }  %>
 

--- a/app/views/tmdb/director_search.html.erb
+++ b/app/views/tmdb/director_search.html.erb
@@ -1,11 +1,11 @@
 <article id="profile">
   <div class="row">
     <div class="summary-box">
-      <%= image_tag(TmdbImageService.image_url(file_path: @person_profile.profile_path, size: :medium, image_type: :profile)) %>
+      <%= image_tag(TmdbImageService.image_url(file_path: @director.profile.profile_path, size: :medium, image_type: :profile)) %>
       <div class="contents">
-        <h1><%= @person_profile.name %></h1>
-        <h2>Born: <%= display_birthday_info(@person_profile) %></h2>
-        <p class="bio"><%= @person_profile.bio %></p>
+        <h1><%= @director.profile.name %></h1>
+        <h2>Born: <%= display_birthday_info(@director.profile) %></h2>
+        <p class="bio"><%= @director.profile.bio %></p>
       </div> <!-- contents -->
     </div> <!-- summary-box -->
   </div> <!-- row -->
@@ -13,7 +13,7 @@
   <div class="row">
     <div class="credits">
 
-      <%= render "director_credits" %>
+      <%= render partial "director_credits", locals: { movie_credits: @director.movie_credits, tv_credits: @director.tv_credits }  %>
 
       <%= render "producer_credits" %>
 
@@ -25,7 +25,7 @@
 
       <%= render "movie_credits" %>
 
-      <%= render "tv_credits" %>
+      <%= render partial "tv_credits", locals: { tv_credits: @director.tv_credits, actor_id: @director.person_id }  %>
 
     </div> <!-- credits -->
   </div> <!-- row -->

--- a/app/views/tmdb/director_search.html.erb
+++ b/app/views/tmdb/director_search.html.erb
@@ -12,8 +12,8 @@
 
   <div class="row">
     <div class="credits">
+      <%= render partial: "director_credits", locals: { movie_credits: @director.movie_credits, tv_credits: @director.tv_credits }  %>
 
-      <%= render partial "director_credits", locals: { movie_credits: @director.movie_credits, tv_credits: @director.tv_credits }  %>
 
       <%= render "producer_credits" %>
       <%= render partial: "editor_credits", locals: { movie_credits: @director.movie_credits, tv_credits: @director.tv_credits }  %>

--- a/app/views/tmdb/director_search.html.erb
+++ b/app/views/tmdb/director_search.html.erb
@@ -16,8 +16,8 @@
       <%= render partial "director_credits", locals: { movie_credits: @director.movie_credits, tv_credits: @director.tv_credits }  %>
 
       <%= render "producer_credits" %>
+      <%= render partial: "editor_credits", locals: { movie_credits: @director.movie_credits, tv_credits: @director.tv_credits }  %>
 
-      <%= render "editor_credits" %>
 
       <%= render "writer_credits" %>
 

--- a/app/views/tmdb/director_search.html.erb
+++ b/app/views/tmdb/director_search.html.erb
@@ -20,13 +20,11 @@
 
       <%= render partial: "writer_credits", locals: { movie_credits: @director.movie_credits, tv_credits: @director.tv_credits }  %>
 
+      <%= render partial: "screenplay_credits", locals: { movie_credits: @director.movie_credits, tv_credits: @director.tv_credits }  %>
 
-      <%= render "screenplay_credits" %>
       <%= render partial: "movie_credits", locals: { movie_credits: @director.movie_credits, person_profile: @director.profile }  %>
 
-
-      <%= render partial "tv_credits", locals: { tv_credits: @director.tv_credits, actor_id: @director.person_id }  %>
-
-    </div> <!-- credits -->
-  </div> <!-- row -->
+      <%= render partial: "tv_credits", locals: { tv_credits: @director.tv_credits, actor_id: @director.person_id }  %>
+    </div>
+  </div>
 </article>

--- a/app/views/tmdb/director_search.html.erb
+++ b/app/views/tmdb/director_search.html.erb
@@ -14,8 +14,8 @@
     <div class="credits">
       <%= render partial: "director_credits", locals: { movie_credits: @director.movie_credits, tv_credits: @director.tv_credits }  %>
 
+      <%= render partial: "producer_credits", locals: { movie_credits: @director.movie_credits, tv_credits: @director.tv_credits }  %>
 
-      <%= render "producer_credits" %>
       <%= render partial: "editor_credits", locals: { movie_credits: @director.movie_credits, tv_credits: @director.tv_credits }  %>
 
 

--- a/app/views/tmdb/director_search.html.erb
+++ b/app/views/tmdb/director_search.html.erb
@@ -18,8 +18,8 @@
 
       <%= render partial: "editor_credits", locals: { movie_credits: @director.movie_credits, tv_credits: @director.tv_credits }  %>
 
+      <%= render partial: "writer_credits", locals: { movie_credits: @director.movie_credits, tv_credits: @director.tv_credits }  %>
 
-      <%= render "writer_credits" %>
 
       <%= render "screenplay_credits" %>
       <%= render partial: "movie_credits", locals: { movie_credits: @director.movie_credits, person_profile: @director.profile }  %>

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -135,15 +135,19 @@ module TmdbHandler
   def tmdb_handler_person_detail_search(person_id)
     api_bio_url = "#{BASE_URL}/person/#{person_id}?api_key=#{ENV['tmdb_api_key']}"
     bio_results = JSON.parse(open(api_bio_url).read, symbolize_names: true)
-    @person_profile = MoviePersonProfile.parse_result(bio_results)
 
     api_movie_credits_url = "#{BASE_URL}/person/#{person_id}/movie_credits?api_key=#{ENV['tmdb_api_key']}"
     movie_credits_results = JSON.parse(open(api_movie_credits_url).read, symbolize_names: true)
-    @person_movie_credits = MoviePersonCredits.parse_result(movie_credits_results)
 
     api_tv_credits_url = "#{BASE_URL}/person/#{person_id}/tv_credits?api_key=#{ENV['tmdb_api_key']}"
     tv_credits_results = JSON.parse(open(api_tv_credits_url).read, symbolize_names: true)
-    @person_tv_credits = TVPersonCredits.parse_result(tv_credits_results)
+
+    OpenStruct.new(
+      person_id: person_id,
+      profile: MoviePersonProfile.parse_result(bio_results),
+      movie_credits: MoviePersonCredits.parse_result(movie_credits_results),
+      tv_credits: TVPersonCredits.parse_result(tv_credits_results)
+    )
   end
 
   def tmdb_handler_actor_credit(credit_id)

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -128,10 +128,6 @@ module TmdbHandler
     raise TmdbHandlerError.new("#{movie.title} failed update. #{error.message}")
   end
 
-  def tmdb_handler_actor_more(actor_id)
-    tmdb_handler_person_detail_search(actor_id)
-  end
-
   def tmdb_handler_person_detail_search(person_id)
     api_bio_url = "#{BASE_URL}/person/#{person_id}?api_key=#{ENV['tmdb_api_key']}"
     bio_results = JSON.parse(open(api_bio_url).read, symbolize_names: true)


### PR DESCRIPTION
## Problems Solved
While working on https://github.com/mikevallano/tmdb-moviequeue/pull/264, I found myself in the swirling twirling land of instance variable monsters. I opened this PR to start chipping away at some of those instance variables that we'd set in the `TmdbHandler` and `tmdb_controller`. Since this work can spiral, my goal was to keep this PR as small as possible. I was able to clean up 2 controller methods, 2 tmdb_handler methods, and a handful of partials. 

I'd like to continue this work in subsequent PRs, trying to keep them as small as possible.

## Risk
These little beasties are sneaky. I traced the code of every time these views are rendered and made sure anyone who renders the partial has the data needed to render it properly. A failure would look like a `NilClass` error. Aside from tests, attentive code tracing, and browser testing, I'm not sure how else to mitigate this risk.


## TODO:
`tmdb_controller` actions:
- [x] `director_search`
  - [x] erb: director_search
    - [x] partial: `director_credits`
    - [x] partial: `tv_credits`
    - [x] partial: `producer_credits`
    - [x] partial: `editor_credits`
    - [x] partial: `writer_credits`
    - [x] partial: `screenplay_credits`
    - [x] partial: `movie_credits`
- [x] `actor_more`
  - [x] erb: actor_more
    - [x] partial: `movie_credits`
    - [x] partial: `director_credits`
    - [x] partial: `tv_credits`
    - [x] partial: `producer_credits`
    - [x] partial: `editor_credits`
    - [x] partial: `writer_credits`
    - [x] partial: `screenplay_credits`
