### PR TITLE
Reduce intance variables in autocomplete methods

### DIFF
--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -18,13 +18,13 @@ class TmdbController < ApplicationController
   end
 
   def movie_autocomplete
-    tmdb_handler_movie_autocomplete(params[:term])
-    render json: @autocomplete_results
+    results = tmdb_handler_movie_autocomplete(params[:term])
+    render json: results
   end
 
   def person_autocomplete
-    tmdb_handler_person_autocomplete(params[:term])
-    render json: @autocomplete_results
+    results = tmdb_handler_person_autocomplete(params[:term])
+    render json: results
   end
 
   def movie_more

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -24,16 +24,16 @@ module TmdbHandler
   end
 
   def tmdb_handler_movie_autocomplete(query)
-    @search_url = "#{BASE_URL}/search/movie?query=#{query}&api_key=#{ENV['tmdb_api_key']}"
-    @tmdb_response = JSON.parse(open(@search_url).read, symbolize_names: true)
-    @autocomplete_results = @tmdb_response[:results].map{ |result| result[:title] }.uniq
+    search_url = "#{BASE_URL}/search/movie?query=#{query}&api_key=#{ENV['tmdb_api_key']}"
+    tmdb_response = JSON.parse(open(search_url).read, symbolize_names: true)
+    tmdb_response[:results].map{ |result| result[:title] }.uniq
   end
 
   def tmdb_handler_person_autocomplete(query)
-    @search_url = "#{BASE_URL}/search/multi?query=#{query}&api_key=#{ENV['tmdb_api_key']}"
-    @tmdb_response = JSON.parse(open(@search_url).read, symbolize_names: true)
-    @person_results = @tmdb_response[:results].select{ |result| result[:media_type] == "person"}
-    @autocomplete_results = @person_results.map{ |result| result[:name] }.uniq
+    search_url = "#{BASE_URL}/search/multi?query=#{query}&api_key=#{ENV['tmdb_api_key']}"
+    tmdb_response = JSON.parse(open(search_url).read, symbolize_names: true)
+    person_results = tmdb_response[:results].select{ |result| result[:media_type] == "person"}
+    person_results.map{ |result| result[:name] }.uniq
   end
 
   def tmdb_handler_movie_more(id)


### PR DESCRIPTION
## Problems Solved
This is part of the ongoing campaign to reduce instance variables being generated in the `TmdbHandler` and related files (Issue #268). In this PR, I've focused on the two autocomplete methods for movies and people.

## Risk
Searching is the most important function of our application. That in itself carries risk. The good new is, the work in this PR was so minimal that very little changes.

### Browser testing
I've browser tested all of these places and confirmed that autocomplete is working as-expected.

#### for tmdb_handler_movie_autocomplete
- [x] http://localhost:3000/ in the top search bar
- [x] http://localhost:3000/ in the search bar in the middle of the page
- [x] http://localhost:3000/tmdb/search
- [x] http://localhost:3000/tmdb/two_movie_search
#### for tmdb_handler_person_autocomplete
- [x] http://localhost:3000/tmdb/actor_search
- [x] http://localhost:3000/tmdb/discover_search
- [x] http://localhost:3000/tmdb/two_actor_search

## Code Tracing
I've outlined all of the places these changes impact and have checked them all.
- [x] tmdb_handler_movie_autocomplete
  * generates these instance variables:
    * @search_url
    * @tmdb_response
    * @autocomplete_results
  * is called by:
    - [x] tmdb_controller#movie_autocomplete
      * rendering in these views:
        - [x] _header.html.erb
        - [x] pages/home.html.erb
        - [x] tmdb/search.html.erb x2
        - [x] tmdb/two_movie_search.html.erb x2

- [x] tmdb_handler_person_autocomplete
  * generates these instance variables:
    * @search_url
    * @tmdb_response
    * @person_results
    * @autocomplete_results
  * is called by:
    - [x] tmdb_controller#person_autocomplete
      * rendering in these views:
        - [x] actor_search.html.erb
        - [x] discover_search.html.erb
        - [x] two_actor_search.html.erb x 2
          