### PR TITLE
Reduce instance variables in tmdb_handler_full_cast

### DIFF
--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -47,10 +47,9 @@ class TmdbController < ApplicationController
 
   def full_cast
     if params[:tmdb_id]
-      @tmdb_id = params[:tmdb_id]
-      tmdb_handler_full_cast(@tmdb_id)
+      @cast = tmdb_handler_full_cast(params[:tmdb_id])
     end
-  end #full cast
+  end
 
   def actor_search
     if params[:actor]

--- a/app/views/tmdb/full_cast.html.erb
+++ b/app/views/tmdb/full_cast.html.erb
@@ -6,43 +6,41 @@
   <div class="row">
     <div class="col-xs-8">
       <h2>Actors:</h2>
-
       <% @cast.actors.each do |actor| %>
-      <div class="headshot-container">
-      <%= link_to headshot_for(actor), actor_more_path(actor_id: actor.actor_id) %>
-        <div class="name-block">
-        <p class="actor"><%= link_to truncate(actor.name, length: 18 ), actor_more_path(actor_id: actor.actor_id) %></p>
-          <p>As <%= truncate(actor.character_name, length: 18, separator: " ") %><p>
-        </div> <!-- name-block -->
-      </div> <!-- headshot-container -->
+        <div class="headshot-container">
+          <%= link_to headshot_for(actor), actor_more_path(actor_id: actor.actor_id) %>
+          <div class="name-block">
+            <p class="actor"><%= link_to truncate(actor.name, length: 18 ), actor_more_path(actor_id: actor.actor_id) %></p>
+            <p>as <%= truncate(actor.character_name, length: 18, separator: " ") %><p>
+          </div> <!-- name-block -->
+        </div> <!-- headshot-container -->
       <% end %><!-- actors each do -->
     </div> <!-- col-xs-8 -->
 
     <div class="col-xs-4">
       <div class="row">
         <h2>Directors:</h2>
-
         <% @cast.directors.each do |director| %>
-        <div class="headshot-container">
-        <%= link_to headshot_for(director), director_search_path(director_id: director.director_id) %>
-          <div class="name-block">
-          <p class="actor"><%= link_to truncate(director.name, length: 18 ), director_search_path(director_id: director.director_id) %></p>
-            <p><%= director.job %><p>
-          </div> <!-- name-block -->
-        </div> <!-- headshot-container -->
+          <div class="headshot-container">
+            <%= link_to headshot_for(director), director_search_path(director_id: director.director_id) %>
+            <div class="name-block">
+              <p class="actor"><%= link_to truncate(director.name, length: 18 ), director_search_path(director_id: director.director_id) %></p>
+              <p><%= director.job %><p>
+            </div> <!-- name-block -->
+          </div> <!-- headshot-container -->
         <% end %><!-- directors each do -->
       </div> <!-- row -->
 
       <div class="row">
         <h2>Editors:</h2>
         <% @cast.editors.each do |editor| %>
-        <div class="headshot-container">
-        <%= link_to headshot_for(editor), director_search_path(director_id: editor.editor_id) %>
-          <div class="name-block">
-            <p class="actor"><%= link_to truncate(editor.name, length: 18 ), director_search_path(director_id: editor.editor_id) %></p>
-            <p><%= editor.job %><p>
-          </div> <!-- name-block -->
-        </div> <!-- headshot-container -->
+          <div class="headshot-container">
+            <%= link_to headshot_for(editor), director_search_path(director_id: editor.editor_id) %>
+            <div class="name-block">
+              <p class="actor"><%= link_to truncate(editor.name, length: 18 ), director_search_path(director_id: editor.editor_id) %></p>
+              <p><%= editor.job %><p>
+            </div> <!-- name-block -->
+          </div> <!-- headshot-container -->
         <% end %><!-- editors each do -->
       </div> <!-- row -->
     </div> <!-- col-xs-4 -->

--- a/app/views/tmdb/full_cast.html.erb
+++ b/app/views/tmdb/full_cast.html.erb
@@ -1,14 +1,13 @@
 <% content_for(:title, "Full Cast") %>
 
 <div class="full-cast">
-
-  <h1>Full cast for <%= link_to "#{@movie.title}", movie_more_path(tmdb_id: @movie.tmdb_id) %></h1>
+  <h1>Full cast for <%= link_to "#{@cast.movie.title}", movie_more_path(tmdb_id: @cast.movie.tmdb_id) %></h1>
 
   <div class="row">
     <div class="col-xs-8">
       <h2>Actors:</h2>
 
-      <% @actors.each do |actor| %>
+      <% @cast.actors.each do |actor| %>
       <div class="headshot-container">
       <%= link_to headshot_for(actor), actor_more_path(actor_id: actor.actor_id) %>
         <div class="name-block">
@@ -23,7 +22,7 @@
       <div class="row">
         <h2>Directors:</h2>
 
-        <% @directors.each do |director| %>
+        <% @cast.directors.each do |director| %>
         <div class="headshot-container">
         <%= link_to headshot_for(director), director_search_path(director_id: director.director_id) %>
           <div class="name-block">
@@ -36,8 +35,7 @@
 
       <div class="row">
         <h2>Editors:</h2>
-
-        <% @editors.each do |editor| %>
+        <% @cast.editors.each do |editor| %>
         <div class="headshot-container">
         <%= link_to headshot_for(editor), director_search_path(director_id: editor.editor_id) %>
           <div class="name-block">
@@ -47,9 +45,6 @@
         </div> <!-- headshot-container -->
         <% end %><!-- editors each do -->
       </div> <!-- row -->
-
     </div> <!-- col-xs-4 -->
-
   </div> <!-- row -->
-
 </div> <!-- full-cast -->

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -45,18 +45,21 @@ module TmdbHandler
   end
 
   def tmdb_handler_full_cast(tmdb_id)
-    @movie_url = "#{BASE_URL}/movie/#{tmdb_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=credits"
-    @result = JSON.parse(open(@movie_url).read, symbolize_names: true)
+    movie_url = "#{BASE_URL}/movie/#{tmdb_id}?api_key=#{ENV['tmdb_api_key']}&append_to_response=credits"
+    result = JSON.parse(open(movie_url).read, symbolize_names: true)
+    director_credits = result[:credits][:crew].select { |crew| crew[:job] == "Director" }
+    editor_credits = result[:credits][:crew].select { |crew| crew[:job] == "Editor" }
+
+    # this gives us the @movie value
     tmdb_handler_movie_more(tmdb_id)
-    @credits = @result[:credits]
-    @cast = @result[:credits][:cast]
-    @actors = MovieCast.parse_results(@cast)
-    @crew = @result[:credits][:crew]
-    @director_credits = @crew.select { |crew| crew[:job] == "Director" }
-    @directors = MovieDirecting.parse_results(@director_credits)
-    @editor_credits = @crew.select { |crew| crew[:job] == "Editor" }
-    @editors = MovieEditing.parse_results(@editor_credits)
-  end #full_cast
+
+    OpenStruct.new(
+      movie: @movie,
+      actors: MovieCast.parse_results(result[:credits][:cast]),
+      directors: MovieDirecting.parse_results(director_credits),
+      editors: MovieEditing.parse_results(editor_credits),
+    )
+  end
 
   def tmdb_handler_add_movie(tmdb_id)
     tmdb_handler_movie_more(tmdb_id)


### PR DESCRIPTION
## Related Issues & PRs
Closes #271
Relates to #270

## Problems Solved
This PR cleans up the instance variables in the `tmdb_handler_full_cast` method. It is imperfect, as there is related work to clean up the `tmdb_handler_movie_more` method. However, this does chip away a little bit more at our instance variable reduction goal outlined in #270.

## Risk
This method is only called in once place, which is the tmdb_controller. Data from this method is only rendered in a single view (full_cast.html.erb) and there are no partials in that view. It is safe to remove any of the instance variables that are not used in these views or subsequent partials. In addition, even though this method inherits a ton of instance variables from these methods

```
tmdb_handler_movie_more
MovieCast.parse_results
MovieDirecting.parse_results
MovieEditing.parse_results
```

The only 4 that are used in the view are `@movie`, `@actors`, `@directors`, and `@editors`. While it is untidy to let the other ones float around in the universe, they don't post an immediate risk and can be cleaned up in subsequent PRs.

## Browser testing
There is only one view that this change affects. Phew! So you can verify easily by going to any movie's "Full Cast" page. 
- [x] http://localhost:3000/tmdb/full_cast?tmdb_id=23483

