### PR TITLE
Reduce instance variables in tmdb_handler_movie_more

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ListingsController < ApplicationController
   before_action :authenticate_user!
 

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -6,12 +6,8 @@ class ListingsController < ApplicationController
   def create
     @listing = current_user.listings.new(listing_params)
     @tmdb_id = params[:tmdb_id]
+    @movie = Movie.find_by(tmdb_id: @tmdb_id) || tmdb_handler_add_movie(@tmdb_id)
 
-    unless Movie.exists?(tmdb_id: @tmdb_id)
-      tmdb_handler_add_movie(@tmdb_id)
-    end
-
-    @movie = Movie.find_by_tmdb_id(@tmdb_id)
     @listing.movie_id = @movie.id
     @listing.user_id = current_user.id
 

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MoviesController < ApplicationController
   before_action :authenticate_user!
   before_action :restrict_to_admin!, only: :update
@@ -21,13 +23,11 @@ class MoviesController < ApplicationController
       @movies = current_user.all_movies_by_recently_watched.paginate(:page => params[:page], per_page: 20)
     end #if params tag
 
-
     @sort_by = params[:sort_by]
     if @sort_by.present?
       movies_index_sort_handler(@sort_by)
     end #if @sort_by.present?
-
-  end #index
+  end
 
   def update
     if @movie.update(required_params)
@@ -64,8 +64,6 @@ class MoviesController < ApplicationController
       @movie = Movie.friendly.find(params[:movie_id])
     end
   end
-
-  private
 
   def required_params
     trailer_url = params[:trailer]

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -46,22 +46,12 @@ class MoviesController < ApplicationController
 
   def modal
     @list = List.find(params[:list_id]) if params[:list_id].present?
-    @tmdb_id = params[:tmdb_id]
-    if Movie.exists?(tmdb_id: @tmdb_id)
-      @movie = Movie.find_by(tmdb_id: @tmdb_id)
-    else
-      tmdb_handler_movie_more(@tmdb_id)
-    end
+    @movie = Movie.find_by(tmdb_id: params[:tmdb_id]) || tmdb_handler_movie_more(params[:tmdb_id])
     respond_to :js
   end
 
   def modal_close
-    @tmdb_id = params[:tmdb_id]
-    if Movie.exists?(tmdb_id: @tmdb_id)
-      @movie = Movie.find_by(tmdb_id: @tmdb_id)
-    else
-      tmdb_handler_movie_more(@tmdb_id)
-    end
+    @movie = Movie.find_by(tmdb_id: params[:tmdb_id]) || tmdb_handler_movie_more(params[:tmdb_id])
     respond_to :js
   end
 
@@ -69,15 +59,11 @@ class MoviesController < ApplicationController
 
   def set_movie
     if params[:tmdb_id].present?
-      @tmdb_id = params[:tmdb_id]
-      unless Movie.exists?(tmdb_id: @tmdb_id)
-        tmdb_handler_add_movie(@tmdb_id)
-      end
-        @movie = Movie.find_by(tmdb_id: @tmdb_id)
-      else
-        @movie = Movie.friendly.find(params[:movie_id])
+      @movie = Movie.find_by(tmdb_id: params[:tmdb_id]) || tmdb_handler_add_movie(params[:tmdb_id])
+    else
+      @movie = Movie.friendly.find(params[:movie_id])
     end
-  end #set movie
+  end
 
   private
 

--- a/app/controllers/screenings_controller.rb
+++ b/app/controllers/screenings_controller.rb
@@ -63,25 +63,20 @@ class ScreeningsController < ApplicationController
 
   private
 
-    def set_screening
-      :set_movie
-      @screening = @movie.screenings.by_user(current_user).find(params[:id])
-    end
+  def set_screening
+    :set_movie
+    @screening = @movie.screenings.by_user(current_user).find(params[:id])
+  end
 
-    def set_movie
-      if params[:tmdb_id].present?
-        @tmdb_id = params[:tmdb_id]
-        unless Movie.exists?(tmdb_id: @tmdb_id)
-          tmdb_handler_add_movie(@tmdb_id)
-        end
-        @movie = Movie.find_by(tmdb_id: @tmdb_id)
-      else
-        @movie = Movie.friendly.find(params[:movie_id])
-      end
+  def set_movie
+    if params[:tmdb_id].present?
+      @movie = Movie.find_by(tmdb_id: params[:tmdb_id]) || tmdb_handler_add_movie(params[:tmdb_id])
+    else
+      @movie = Movie.friendly.find(params[:movie_id])
     end
+  end
 
-    def screening_params
-      params.require(:screening).permit(:user_id, :movie_id, :date_watched, :location_watched, :notes, :tmdb_id)
-    end
-
+  def screening_params
+    params.require(:screening).permit(:user_id, :movie_id, :date_watched, :location_watched, :notes, :tmdb_id)
+  end
 end

--- a/app/controllers/screenings_controller.rb
+++ b/app/controllers/screenings_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ScreeningsController < ApplicationController
   include TmdbHandler
 

--- a/app/controllers/screenings_controller.rb
+++ b/app/controllers/screenings_controller.rb
@@ -66,7 +66,6 @@ class ScreeningsController < ApplicationController
   private
 
   def set_screening
-    :set_movie
     @screening = @movie.screenings.by_user(current_user).find(params[:id])
   end
 

--- a/app/controllers/taggings_controller.rb
+++ b/app/controllers/taggings_controller.rb
@@ -28,7 +28,7 @@ class TaggingsController < ApplicationController
     end
   end
 
-private
+  private
 
   def tagging_params
     params.require(:tagging).permit(:tag_id, :tag_list, :movie_id, :user_id, :tmdb_id)
@@ -36,14 +36,9 @@ private
 
   def set_movie
     if params[:tmdb_id].present?
-      @tmdb_id = params[:tmdb_id]
-      unless Movie.exists?(tmdb_id: @tmdb_id)
-        tmdb_handler_add_movie(@tmdb_id)
-      end
-        @movie = Movie.find_by(tmdb_id: @tmdb_id)
-      else
-        @movie = Movie.friendly.find(params[:movie_id])
+      @movie = Movie.find_by(tmdb_id: params[:tmdb_id]) || tmdb_handler_add_movie(params[:tmdb_id])
+    else
+      @movie = Movie.friendly.find(params[:movie_id])
     end
-  end #set movie
-
+  end
 end

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -29,8 +29,7 @@ class TmdbController < ApplicationController
 
   def movie_more
     if params[:tmdb_id]
-      @tmdb_id = params[:tmdb_id]
-      tmdb_handler_movie_more(@tmdb_id)
+      @movie = tmdb_handler_movie_more(params[:tmdb_id])
     else
       redirect_to api_search_path
     end

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TmdbController < ApplicationController
   before_action :authenticate_user!
 

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,5 +1,6 @@
-class Movie < ActiveRecord::Base
+# frozen_string_literal: true
 
+class Movie < ActiveRecord::Base
   self.per_page = 20
 
   extend FriendlyId
@@ -10,21 +11,15 @@ class Movie < ActiveRecord::Base
   has_many :listings
   has_many :lists, through: :listings
   has_many :users, through: :listings
-
-  def self.by_tag_and_user(tag, user)
-    joins(:taggings).where(taggings: { user_id: user.id }).where(taggings: { tag_id: tag.id })
-  end
-
   has_many :taggings
   has_many :tags, through: :taggings
-
   has_many :reviews
-
   has_many :ratings
-
   has_many :screenings
   has_many :viewers, :through => :screenings,
   :source => :user
+
+  attr_accessor :production_companies
 
   LIST_SORT_OPTIONS = [ ["title", "title"], ["shortest runtime", "shortest runtime"],
   ["longest runtime", "longest runtime"], ["newest release", "newest release"],
@@ -39,6 +34,18 @@ class Movie < ActiveRecord::Base
   ["unwatched movies", "unwatched movies"], ["only show unwatched", "only show unwatched"],
   ["only show watched", "only show watched"], ["movies not on a list", "movies not on a list"] ]
 
+  GENRES = [["Action", 28], ["Adventure", 12], ["Animation", 16], ["Comedy", 35], ["Crime", 80],
+  ["Documentary", 99], ["Drama", 18], ["Family", 10751], ["Fantasy", 14], ["Foreign", 10769], ["History", 36],
+  ["Horror", 27], ["Music", 10402], ["Mystery", 9648], ["Romance", 10749], ["Science Fiction", 878], ["TV Movie", 10770],
+  ["Thriller", 53], ["War", 10752], ["Western", 37]]
+
+  MPAA_RATINGS = [ ["R", "R"], ["NC-17", "NC-17"], ["PG-13", "PG-13"], ["G", "G"] ]
+
+  SORT_BY = [ ["Popularity", "popularity"], ["Release date", "release_date"], ["Revenue", "revenue"],
+  ["Vote average", "vote_average"], ["Vote count","vote_count"] ]
+
+  YEAR_SELECT = [ ["Exact Year", "exact"], ["After This Year", "after"], ["Before This Year", "before"] ]
+
   scope :by_title, -> { order(:title) }
   scope :by_shortest_runtime, -> { order(:runtime) }
   scope :by_longest_runtime, -> { order(:runtime).reverse_order }
@@ -46,6 +53,10 @@ class Movie < ActiveRecord::Base
   scope :by_highest_vote_average, -> { order(:vote_average).reverse_order }
   scope :default_list_order, -> (list) do
     list.movies.order('CAST(listings.created_at as DATE) desc, listings.priority desc')
+  end
+
+  def self.by_tag_and_user(tag, user)
+    joins(:taggings).where(taggings: { user_id: user.id }).where(taggings: { tag_id: tag.id })
   end
 
   def self.by_highest_priority(list)
@@ -117,29 +128,11 @@ class Movie < ActiveRecord::Base
   def priority_text(list)
     p = listings.find_by(list_id: list.id).priority
     case p
-    when 1
-      "Bottom"
-    when 2
-      "Low"
-    when 3
-      "Normal"
-    when 4
-      "High"
-    when 5
-      "Top"
+    when 1 then "Bottom"
+    when 2 then "Low"
+    when 3 then "Normal"
+    when 4 then "High"
+    when 5 then "Top"
     end
-  end #priority_text
-
-  GENRES = [["Action", 28], ["Adventure", 12], ["Animation", 16], ["Comedy", 35], ["Crime", 80],
-  ["Documentary", 99], ["Drama", 18], ["Family", 10751], ["Fantasy", 14], ["Foreign", 10769], ["History", 36],
-  ["Horror", 27], ["Music", 10402], ["Mystery", 9648], ["Romance", 10749], ["Science Fiction", 878], ["TV Movie", 10770],
-  ["Thriller", 53], ["War", 10752], ["Western", 37]]
-
-  MPAA_RATINGS = [ ["R", "R"], ["NC-17", "NC-17"], ["PG-13", "PG-13"], ["G", "G"] ]
-
-  SORT_BY = [ ["Popularity", "popularity"], ["Release date", "release_date"], ["Revenue", "revenue"],
-  ["Vote average", "vote_average"], ["Vote count","vote_count"] ]
-
-  YEAR_SELECT = [ ["Exact Year", "exact"], ["After This Year", "after"], ["Before This Year", "before"] ]
-
+  end
 end

--- a/app/models/movie_more.rb
+++ b/app/models/movie_more.rb
@@ -1,104 +1,75 @@
+# frozen_string_literal: true
+
 class MovieMore
-  def initialize(title, in_db, tmdb_id, release_date, vote_average, genres, overview, actors,
-    backdrop_path, poster_path, trailer, imdb_id, mpaa_rating, director,
-    director_id, adult, popularity, runtime, tags, lists)
+  attr_accessor :actors, :adult, :backdrop_path, :crew, :director, :director_id, :genres, :imdb_id, :lists, :mpaa_rating, :overview, :popularity, :poster_path, :production_companies, :release_date, :runtime, :tags, :title, :tmdb_id, :trailer, :vote_average
 
-    @title = title
-    @in_db = in_db
-    @tmdb_id = tmdb_id
-    @release_date = release_date
-    @vote_average = vote_average
-    @genres = genres
-    @overview = overview
-    @actors = actors
-    @backdrop_path = backdrop_path
-    @poster_path = poster_path
-    @trailer = trailer
-    @imdb_id = imdb_id
-    @mpaa_rating = mpaa_rating
-    @director = director
-    @director_id = director_id
-    @adult = adult
-    @popularity = popularity
-    @runtime = runtime
-    @tags = tags
-    @lists = lists
-
+  def initialize(args)
+    @actors = args[:actors]
+    @adult = args[:adult]
+    @backdrop_path = args[:backdrop_path]
+    @crew = args[:crew]
+    @director = args[:director]
+    @director_id = args[:director_id]
+    @lists = args[:lists]
+    @imdb_id = args[:imdb_id]
+    @genres = args[:genres]
+    @overview = args[:overview]
+    @release_date = args[:release_date]
+    @mpaa_rating = args[:mpaa_rating]
+    @popularity = args[:popularity]
+    @poster_path = args[:poster_path]
+    @production_companies = args[:production_companies]
+    @runtime = args[:runtime]
+    @tags = args[:tags]
+    @title = args[:title]
+    @tmdb_id = args[:tmdb_id]
+    @trailer = args[:trailer]
+    @vote_average = args[:vote_average]
   end
-
-  attr_accessor :title, :in_db, :tmdb_id, :release_date, :vote_average, :genres, :overview,
-  :actors, :backdrop_path, :poster_path, :trailer, :imdb_id, :mpaa_rating, :director,
-  :director_id, :adult, :popularity, :runtime, :tags, :lists
 
   def self.parse_result(result)
-    @tmdb_id = result[:id]
-    @in_db = Movie.exists?(tmdb_id: @tmdb_id)
-      if @in_db
-        @movie = Movie.find_by(tmdb_id: @tmdb_id)
-      else
-        self.tmdb_info(result)
-      end #if in_db
-    @movie
+    Movie.find_by(tmdb_id: result[:id]) || tmdb_info(result)
   end
 
-    def times_seen_by(user)
-      0
+  def times_seen_by(user)
+    0
+  end
+
+  def self.tmdb_info(result)
+    release_date = Date.parse(result[:release_date]) if result[:release_date].present?
+    vote_average = result[:vote_average].present? ? result[:vote_average].round(1) : 0
+    runtime = result[:runtime].presence || 0
+
+    trailer = if result[:trailers][:youtube].present?
+      result[:trailers][:youtube][0][:source].presence
     end
 
-    def self.tmdb_info(result)
-        @title = result[:title]
-        @release_date = Date.parse(result[:release_date]) if result[:release_date].present?
-        if result[:vote_average].present?
-          @vote_average = result[:vote_average].round(1)
-        else
-          @vote_average = 0
-        end
-        @genres = result[:genres].map { |genre| genre[:name] }
-        @overview = result[:overview]
-        @actors = result[:credits][:cast].map { |cast| cast[:name] }
-        @backdrop_path = result[:backdrop_path]
-        @poster_path = result[:poster_path]
-        if result[:trailers][:youtube].present?
-          if result[:trailers][:youtube][0][:source].present?
-            @trailer = result[:trailers][:youtube][0][:source]
-          else
-            @trailer = nil
-          end
-        else
-          @trailer = nil
-        end
-        @imdb_id = result[:imdb_id]
-        @adult = result[:adult]
-        @popularity = result[:popularity]
-        if result[:runtime].present?
-          @runtime = result[:runtime]
-        else
-          @runtime = 0
-        end
-        @tags = nil
-        @lists = nil
+    us_movie_releases = result[:releases][:countries].select { |country| country[:iso_3166_1] == "US" }
+    mpaa_rating = us_movie_releases.present? && us_movie_releases.first[:certification].present? ? us_movie_releases.first[:certification] : 'NR'
+    first_director = result[:credits][:crew].find {|crew| crew[:department] == 'Directing'}
 
-        if result[:releases][:countries].select { |country| country[:iso_3166_1] == "US" }.present?
-          if result[:releases][:countries].select { |country| country[:iso_3166_1] == "US" }.first[:certification].present?
-            @mpaa_rating = result[:releases][:countries].select { |country| country[:iso_3166_1] == "US" }.first[:certification]
-          else
-            @mpaa_rating = "NR"
-          end
-        else
-          @mpaa_rating = "NR"
-        end
-
-        @crew = result[:credits][:crew]
-        @crew.find do |crew|
-          if crew[:department] == "Directing"
-            @director = crew[:name]
-            @director_id = crew[:id]
-          end
-        end
-
-        @movie = MovieMore.new(@title, @in_db, @tmdb_id, @release_date, @vote_average, @genres,
-          @overview, @actors, @backdrop_path, @poster_path, @trailer, @imdb_id, @mpaa_rating,
-          @director, @director_id, @adult, @popularity, @runtime, @tags, @lists)
-    end
-
+    new(
+      actors: result[:credits][:cast].map { |cast| cast[:name] },
+      adult: result[:adult],
+      backdrop_path: result[:backdrop_path],
+      crew: result[:credits][:crew],
+      director: first_director[:name],
+      director_id: first_director[:id],
+      genres: result[:genres].map { |genre| genre[:name] },
+      imdb_id: result[:imdb_id],
+      lists: nil,
+      mpaa_rating: mpaa_rating,
+      overview: result[:overview],
+      popularity: result[:popularity],
+      poster_path: result[:poster_path],
+      production_companies: result[:production_companies],
+      release_date: release_date,
+      runtime: runtime,
+      tags: nil,
+      title: result[:title],
+      tmdb_id: result[:id],
+      trailer: trailer,
+      vote_average: vote_average
+    )
+  end
 end

--- a/app/models/movie_more.rb
+++ b/app/models/movie_more.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MovieMore
-  attr_accessor :actors, :adult, :backdrop_path, :crew, :director, :director_id, :genres, :imdb_id, :lists, :mpaa_rating, :overview, :popularity, :poster_path, :production_companies, :release_date, :runtime, :tags, :title, :tmdb_id, :trailer, :vote_average
+  attr_accessor :actors, :adult, :backdrop_path, :crew, :director, :director_id, :genres, :imdb_id, :in_db, :lists, :mpaa_rating, :overview, :popularity, :poster_path, :production_companies, :release_date, :runtime, :tags, :title, :tmdb_id, :trailer, :vote_average
 
   def initialize(args)
     @actors = args[:actors]
@@ -12,6 +12,7 @@ class MovieMore
     @director_id = args[:director_id]
     @lists = args[:lists]
     @imdb_id = args[:imdb_id]
+    @in_db = args[:in_db]
     @genres = args[:genres]
     @overview = args[:overview]
     @release_date = args[:release_date]
@@ -57,6 +58,7 @@ class MovieMore
       director_id: first_director[:id],
       genres: result[:genres].map { |genre| genre[:name] },
       imdb_id: result[:imdb_id],
+      in_db: Movie.exists?(tmdb_id: result[:tmdb_id]),
       lists: nil,
       mpaa_rating: mpaa_rating,
       overview: result[:overview],

--- a/app/views/movies/_movie_show.html.erb
+++ b/app/views/movies/_movie_show.html.erb
@@ -82,16 +82,15 @@
             <% end %> <!-- # tag form loop -->
           <% end %> <!-- # if admin? -->
 
-            <% if @movie.production_companies.present? %> <!-- # if @movie.production_companies.present? -->
+            <% if @movie.production_companies.present? %>
               <p><strong>Production Companies:</strong>
                 <% @movie.production_companies.each do |company| %>
                   <%= link_to "#{company[:name]}", discover_search_path(company: company[:id], sort_by: "release_date") %>
                   <%= ", " unless company == @movie.production_companies.last %>
-                <% end %> <!-- # each -->
+                <% end %>
               </p>
-            <% end %> <!-- # if @movie.production_companies.present? -->
+            <% end %>
           </div> <!-- col-xs-12 -->
-
         </div> <!-- row -->
 
 

--- a/app/views/movies/_movie_show.html.erb
+++ b/app/views/movies/_movie_show.html.erb
@@ -82,14 +82,14 @@
             <% end %> <!-- # tag form loop -->
           <% end %> <!-- # if admin? -->
 
-            <% if @production_companies.present? %> <!-- # if @production_companies.present? -->
+            <% if @movie.production_companies.present? %> <!-- # if @movie.production_companies.present? -->
               <p><strong>Production Companies:</strong>
-                <% @production_companies.each do |company| %>
+                <% @movie.production_companies.each do |company| %>
                   <%= link_to "#{company[:name]}", discover_search_path(company: company[:id], sort_by: "release_date") %>
-                  <%= ", " unless company == @production_companies.last %>
+                  <%= ", " unless company == @movie.production_companies.last %>
                 <% end %> <!-- # each -->
               </p>
-            <% end %> <!-- # if @production_companies.present? -->
+            <% end %> <!-- # if @movie.production_companies.present? -->
           </div> <!-- col-xs-12 -->
 
         </div> <!-- row -->

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -181,25 +181,22 @@ module TmdbHandler
   end
 
   def tmdb_handler_two_movie_search(movie_one_title, movie_two_title)
-    joint_search_results = OpenStruct.new
+    movie_one_results = tmdb_handler_search(movie_one_title)
+    movie_two_results = tmdb_handler_search(movie_two_title)
+    not_found_message = movie_one_results.not_found_message.presence || movie_two_results.not_found_message.presence
 
-    movie_one_search_results = tmdb_handler_search(movie_one_title)
-    movie_one_id = movie_one_search_results&.movies&.first&.tmdb_id
-    movie_two_search_results = tmdb_handler_search(movie_two_title)
-    movie_two_id = movie_two_search_results&.movies&.first&.tmdb_id
-
-    joint_search_results.not_found_message = movie_one_search_results.not_found_message.presence || movie_two_search_results.not_found_message.presence
-
-    if movie_one_id.present? && movie_two_id.present?
-      joint_search_results.movie_one = tmdb_handler_movie_more(movie_one_id)
-      movie_one_actors = joint_search_results.movie_one.actors
-
-      joint_search_results.movie_two = tmdb_handler_movie_more(movie_two_id)
-      movie_two_actors = joint_search_results.movie_two.actors
-
-      joint_search_results.common_actors = movie_one_actors & movie_two_actors
+    if not_found_message.present?
+      OpenStruct.new(not_found_message: not_found_message)
+    else
+      movie_one = tmdb_handler_movie_more(movie_one_results.movies.first.tmdb_id)
+      movie_two = tmdb_handler_movie_more(movie_two_results.movies.first.tmdb_id)
+      OpenStruct.new(
+        movie_one: movie_one,
+        movie_two: movie_two,
+        common_actors: movie_one.actors & movie_two.actors,
+        not_found_message: nil
+      )
     end
-    joint_search_results
   end
 
   def tmdb_handler_discover_search(params)

--- a/lib/tmdb_handler.rb
+++ b/lib/tmdb_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TmdbHandler
   BASE_URL = 'https://api.themoviedb.org/3'.freeze
 


### PR DESCRIPTION
## Related Issues & PRs
Closes #268
Relates to #270
Blocking #276

## Problems Solved
This PR cleans up the instance variables in the tmdb_handler_movie_more method and related class. It follows the code through where this method is called but stops short of getting the views and partials up to date with using locals instead of instance variables. That work gets squirreley 🦑  and I'm saving it to do last because I want to have all of the other methods' instance variables reduced first. I've added it as a line item in #270.

I recommend turning off the whitespace changes in the diff since I made some changes to indenting.

## Risk
I outlined all the code tracing I've done in this PR in the original issue #268. I've also browser tested all of the parts of the app (i think) that these files obviously touch.

### How to test in the browser
- [x] check that the `movie_more` page still loads correctly http://localhost:3000/tmdb/movie_more?tmdb_id=429197
- [x] check that the modal opens and closes
- [x] check that you can still add a movie to a list 
  - [x] from the show page
  - [x] from the modal
- [x] add a screening 
  - [x] from the modal of an unsaved movie
  - [x] from the show page of a saved movie http://localhost:3000/movies/vice
- [x] add a tag
  - [x] from the modal of an unsaved movie
  - [x] from the show page of a saved movie http://localhost:3000/movies/vice

## Things Learned
* It was nice to slap an `attr_accessor` on the `Movie` class to help bridge the gap between that class and the `MovieMore` class. More about that in #278.
