### PR TITLE
281: Handle when there is no director data

### DIFF
--- a/app/models/movie_more.rb
+++ b/app/models/movie_more.rb
@@ -47,8 +47,7 @@ class MovieMore
 
     us_movie_releases = result[:releases][:countries].select { |country| country[:iso_3166_1] == "US" }
     mpaa_rating = us_movie_releases.present? && us_movie_releases.first[:certification].present? ? us_movie_releases.first[:certification] : 'NR'
-    first_director = result[:credits][:crew].find {|crew| crew[:department] == 'Directing'}
-
+    first_director = result[:credits][:crew].find {|crew| crew[:department] == 'Directing'}.presence || {}
     new(
       actors: result[:credits][:cast].map { |cast| cast[:name] },
       adult: result[:adult],


### PR DESCRIPTION
## Related Issues & PRs
Closes #281

## Problems Solved
* Fixes bug that blows up when no director data

## Screenshots
N/A

## Things Learned
* I "learned" that we have a daily task to refresh data from TMDB 😆 
* It would be much better if we had more data (like tmdb_id) on the movie that errored. Separate issue to have more data sent to sentry: https://github.com/mikevallano/tmdb-moviequeue/issues/282
