### PR TITLE
Rename Tmdb::Client methods to be more idiomatic

### DIFF
--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -88,7 +88,7 @@ class TmdbController < ApplicationController
     query = show_title = params[:show_title] || params[:show_title_header]
     if query.present?
       @query = I18n.transliterate(query)
-      @search_results = Tmdb::Client.tv_series_search(query)
+      @search_results = Tmdb::Client.get_tv_series_search_results(query)
     end
   end
 

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -93,7 +93,7 @@ class TmdbController < ApplicationController
   end
 
   def tv_series_autocomplete
-    autocomplete_results = Tmdb::Client.tv_series_autocomplete(params[:term])
+    autocomplete_results = Tmdb::Client.get_tv_series_names(params[:term])
     render json: autocomplete_results
   end
 

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -8,7 +8,7 @@ class TmdbController < ApplicationController
 
   def search
     if @movie_title = params[:movie_title] || params[:movie_title_header]
-      @search_results = Tmdb::Client.movie_search(@movie_title)
+      @search_results = Tmdb::Client.get_movie_search_results(@movie_title)
     end
   end
 

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -47,7 +47,7 @@ class TmdbController < ApplicationController
 
   def full_cast
     if params[:tmdb_id]
-      @cast = Tmdb::Client.movie_cast(params[:tmdb_id])
+      @cast = Tmdb::Client.get_movie_cast(params[:tmdb_id])
     end
   end
 

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -19,7 +19,7 @@ class TmdbController < ApplicationController
   end
 
   def movie_autocomplete
-    results = Tmdb::Client.movie_autocomplete(params[:term])
+    results = Tmdb::Client.get_movie_titles(params[:term])
     render json: results
   end
 

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -76,7 +76,7 @@ class TmdbController < ApplicationController
   end
 
   def actor_more
-    @actor = Tmdb::Client.person_detail_search(params[:actor_id])
+    @actor = Tmdb::Client.get_person_profile_data(params[:actor_id])
   end
 
   def actor_credit
@@ -127,7 +127,7 @@ class TmdbController < ApplicationController
 
   def director_search
     if params[:director_id]
-      @director = Tmdb::Client.person_detail_search(params[:director_id])
+      @director = Tmdb::Client.get_person_profile_data(params[:director_id])
     end
   end
 

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -118,7 +118,7 @@ class TmdbController < ApplicationController
       series: @series,
       season_number: season_number
     )
-    @episode = Tmdb::Client.tv_episode(
+    @episode = Tmdb::Client.get_tv_episode_data(
       series_id: series_id,
       season_number: season_number,
       episode_number: params[:episode_number]

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -99,11 +99,11 @@ class TmdbController < ApplicationController
 
   def tv_series
     show_id = params[:show_id]
-    @series = Tmdb::Client.tv_series(show_id)
+    @series = Tmdb::Client.get_tv_series_data(show_id)
   end
 
   def tv_season
-    @series = Tmdb::Client.tv_series(params[:show_id])
+    @series = Tmdb::Client.get_tv_series_data(params[:show_id])
     @season = Tmdb::Client.tv_season(
       series: @series,
       season_number: params[:season_number]
@@ -113,7 +113,7 @@ class TmdbController < ApplicationController
   def tv_episode
     series_id = params[:show_id]
     season_number = params[:season_number]
-    @series = Tmdb::Client.tv_series(series_id)
+    @series = Tmdb::Client.get_tv_series_data(series_id)
     @season = Tmdb::Client.tv_season(
       series: @series,
       season_number: season_number

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -14,7 +14,7 @@ class TmdbController < ApplicationController
 
   def two_movie_search
     if params[:movie_one] && params[:movie_two]
-      @search_results = Tmdb::Client.common_actors_between_movies(params[:movie_one], params[:movie_two])
+      @search_results = Tmdb::Client.get_common_actors_between_movies(params[:movie_one], params[:movie_two])
     end
   end
 

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -104,7 +104,7 @@ class TmdbController < ApplicationController
 
   def tv_season
     @series = Tmdb::Client.get_tv_series_data(params[:show_id])
-    @season = Tmdb::Client.tv_season(
+    @season = Tmdb::Client.get_tv_season_data(
       series: @series,
       season_number: params[:season_number]
     )
@@ -114,7 +114,7 @@ class TmdbController < ApplicationController
     series_id = params[:show_id]
     season_number = params[:season_number]
     @series = Tmdb::Client.get_tv_series_data(series_id)
-    @season = Tmdb::Client.tv_season(
+    @season = Tmdb::Client.get_tv_season_data(
       series: @series,
       season_number: season_number
     )

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -81,7 +81,7 @@ class TmdbController < ApplicationController
 
   def actor_credit
     credit_id = params[:credit_id]
-    @credit = Tmdb::Client.tv_actor_appearance_credits(credit_id)
+    @credit = Tmdb::Client.get_actor_tv_appearance_credits(credit_id)
   end
 
   def tv_series_search

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -24,7 +24,7 @@ class TmdbController < ApplicationController
   end
 
   def person_autocomplete
-    results = Tmdb::Client.person_autocomplete(params[:term])
+    results = Tmdb::Client.get_person_names(params[:term])
     render json: results
   end
 

--- a/lib/tmdb/client.rb
+++ b/lib/tmdb/client.rb
@@ -147,7 +147,7 @@ module Tmdb
         data.select { |result| result[:media_type] == 'person' }&.map { |result| result[:name] }&.uniq
       end
 
-      def person_detail_search(person_id)
+      def get_person_profile_data(person_id)
         person_data = request(:person_data, person_id: person_id)
         movie_credits_data = request(:person_movie_credits, person_id: person_id)
         tv_credits_data = request(:person_tv_credits, person_id: person_id)

--- a/lib/tmdb/client.rb
+++ b/lib/tmdb/client.rb
@@ -160,7 +160,7 @@ module Tmdb
         )
       end
 
-      def tv_actor_appearance_credits(credit_id)
+      def get_actor_tv_appearance_credits(credit_id)
         data = request(:credits_data, credit_id: credit_id)
         TVActorCredit.parse_record(data)
       end

--- a/lib/tmdb/client.rb
+++ b/lib/tmdb/client.rb
@@ -142,7 +142,7 @@ module Tmdb
         end
       end
 
-      def person_autocomplete(query)
+      def get_person_names(query)
         data = request(:multi_search, query: query)[:results]
         data.select { |result| result[:media_type] == 'person' }&.map { |result| result[:name] }&.uniq
       end

--- a/lib/tmdb/client.rb
+++ b/lib/tmdb/client.rb
@@ -57,7 +57,7 @@ module Tmdb
         MovieMore.initialize_from_parsed_data(data)
       end
 
-      def movie_cast(tmdb_movie_id)
+      def get_movie_cast(tmdb_movie_id)
         data = request(:movie_data, movie_id: tmdb_movie_id)
 
         director_credits = data.dig(:credits, :crew)&.select { |crew| crew[:job] == 'Director' }

--- a/lib/tmdb/client.rb
+++ b/lib/tmdb/client.rb
@@ -165,7 +165,7 @@ module Tmdb
         TVActorCredit.parse_record(data)
       end
 
-      def tv_series_autocomplete(query)
+      def get_tv_series_names(query)
         data = request(:tv_series_search, query: query)[:results]
         data.map { |d| d[:name] }.uniq
       end

--- a/lib/tmdb/client.rb
+++ b/lib/tmdb/client.rb
@@ -7,7 +7,7 @@ module Tmdb
     API_KEY = ENV['tmdb_api_key']
 
     class << self
-      def movie_search(movie_title)
+      def get_movie_search_results(movie_title)
         data = request(:movie_search, query: movie_title)[:results]
         not_found = "No results for '#{movie_title}'." if data.blank?
         movies = MovieSearch.parse_results(data) if data.present?
@@ -124,8 +124,8 @@ module Tmdb
       end
 
       def common_actors_between_movies(movie_one_title, movie_two_title)
-        movie_one_results = movie_search(movie_one_title)
-        movie_two_results = movie_search(movie_two_title)
+        movie_one_results = get_movie_search_results(movie_one_title)
+        movie_two_results = get_movie_search_results(movie_two_title)
         not_found_message = movie_one_results.not_found_message.presence || movie_two_results.not_found_message.presence
 
         if not_found_message.present?

--- a/lib/tmdb/client.rb
+++ b/lib/tmdb/client.rb
@@ -71,7 +71,7 @@ module Tmdb
         )
       end
 
-      def movie_autocomplete(query)
+      def get_movie_titles(query)
         data = request(:movie_search, query: query)[:results]
         data.map { |d| d[:title] }.uniq
       end

--- a/lib/tmdb/client.rb
+++ b/lib/tmdb/client.rb
@@ -189,7 +189,7 @@ module Tmdb
         )
       end
 
-      def tv_episode(series_id:, season_number:, episode_number:)
+      def get_tv_episode_data(series_id:, season_number:, episode_number:)
         params = { series_id: series_id, season_number: season_number, episode_number: episode_number }
         data = request(:tv_episode_data, params)
         TVEpisode.parse_record(data)

--- a/lib/tmdb/client.rb
+++ b/lib/tmdb/client.rb
@@ -175,7 +175,7 @@ module Tmdb
         TVSeries.parse_search_records(data) if data.present?
       end
 
-      def tv_series(series_id)
+      def get_tv_series_data(series_id)
         data = request(:tv_series_data, series_id: series_id)
         TVSeries.parse_record(data, series_id)
       end

--- a/lib/tmdb/client.rb
+++ b/lib/tmdb/client.rb
@@ -123,7 +123,7 @@ module Tmdb
         raise Error, "#{movie.title} failed update. #{e.message}"
       end
 
-      def common_actors_between_movies(movie_one_title, movie_two_title)
+      def get_common_actors_between_movies(movie_one_title, movie_two_title)
         movie_one_results = get_movie_search_results(movie_one_title)
         movie_two_results = get_movie_search_results(movie_two_title)
         not_found_message = movie_one_results.not_found_message.presence || movie_two_results.not_found_message.presence

--- a/lib/tmdb/client.rb
+++ b/lib/tmdb/client.rb
@@ -180,7 +180,7 @@ module Tmdb
         TVSeries.parse_record(data, series_id)
       end
 
-      def tv_season(series:, season_number:)
+      def get_tv_season_data(series:, season_number:)
         params = { series_id: series.show_id, season_number: season_number }
         data = request(:tv_season_data, params)
         TVSeason.parse_record(

--- a/lib/tmdb/client.rb
+++ b/lib/tmdb/client.rb
@@ -170,7 +170,7 @@ module Tmdb
         data.map { |d| d[:name] }.uniq
       end
 
-      def tv_series_search(query)
+      def get_tv_series_search_results(query)
         data = request(:tv_series_search, query: query)[:results]
         TVSeries.parse_search_records(data) if data.present?
       end

--- a/spec/lib/tmdb/client_spec.rb
+++ b/spec/lib/tmdb/client_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Tmdb::Client do
       end
     end
 
-    describe '.movie_autocomplete' do
+    describe '.get_movie_titles' do
       it 'returns a list of unique movie names' do
         parsed_data = [
           { title: 'A' },
@@ -160,7 +160,7 @@ RSpec.describe Tmdb::Client do
           { title: 'C' }
         ]
         allow(described_class).to receive(:request).and_return(results: parsed_data)
-        names = described_class.movie_autocomplete("doesn't matter")
+        names = described_class.get_movie_titles("doesn't matter")
         expect(names).to eq(%w[A B C])
       end
     end

--- a/spec/lib/tmdb/client_spec.rb
+++ b/spec/lib/tmdb/client_spec.rb
@@ -589,7 +589,7 @@ RSpec.describe Tmdb::Client do
       end
     end
 
-    describe '.tv_series' do
+    describe '.get_tv_series_data' do
       let(:parsed_tv_series_data) do
         {
           backdrop_path: '/hpU2cHC9tk90hswCFEpf5AtbqoL.jpg',
@@ -627,7 +627,7 @@ RSpec.describe Tmdb::Client do
         allow(described_class).to receive(:request).and_return(parsed_tv_series_data)
       end
       it 'returns a TVSeries object with data' do
-        series = described_class.tv_series('foo')
+        series = described_class.get_tv_series_data('foo')
         expect(series.show_id).to eq('foo')
         expect(series.first_air_date).to eq('12/17/1989')
         expect(series.last_air_date).to eq(nil)

--- a/spec/lib/tmdb/client_spec.rb
+++ b/spec/lib/tmdb/client_spec.rb
@@ -642,7 +642,7 @@ RSpec.describe Tmdb::Client do
       end
     end
 
-    describe '.tv_season' do
+    describe '.get_tv_season_data' do
       let(:tv_series) { build(:tv_series, show_id: 1) }
       let(:parsed_tv_season_data) do
         {
@@ -689,7 +689,7 @@ RSpec.describe Tmdb::Client do
       end
       it 'returns a TVSeason object with data' do
         allow(described_class).to receive(:request).and_return(parsed_tv_season_data)
-        season = described_class.tv_season(series: tv_series, season_number: 'foo')
+        season = described_class.get_tv_season_data(series: tv_series, season_number: 'foo')
 
         expect(season.series.show_id).to eq(1)
         expect(season.show_id).to eq(1)

--- a/spec/lib/tmdb/client_spec.rb
+++ b/spec/lib/tmdb/client_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Tmdb::Client do
   end
 
   describe 'person methods' do
-    describe '.person_autocomplete' do
+    describe '.get_person_names' do
       it 'returns a list of unique actor names' do
         parsed_data = [
           { media_type: 'movie', original_title: 'Jennifer Lopez: Dance Again' },
@@ -231,7 +231,7 @@ RSpec.describe Tmdb::Client do
           { media_type: 'person', name: 'Jennifer Gray' }
         ]
         allow(described_class).to receive(:request).and_return(results: parsed_data)
-        names = described_class.person_autocomplete("doesn't matter")
+        names = described_class.get_person_names("doesn't matter")
         expect(names).to eq(['Jennifer Lopez', 'Jennifer Gray'])
         expect(names).to_not include('Jennifer Lopez: Dance Again')
       end

--- a/spec/lib/tmdb/client_spec.rb
+++ b/spec/lib/tmdb/client_spec.rb
@@ -472,7 +472,7 @@ RSpec.describe Tmdb::Client do
   end
 
   describe 'tv methods' do
-    describe '.tv_actor_appearance_credits' do
+    describe '.get_actor_tv_appearance_credits' do
       let(:parsed_credits) do
         {
           media: {
@@ -525,7 +525,7 @@ RSpec.describe Tmdb::Client do
       end
 
       it 'returns tv_actor_credit data' do
-        person = described_class.tv_actor_appearance_credits('foo')
+        person = described_class.get_actor_tv_appearance_credits('foo')
         expect(person).to be_instance_of(TVActorCredit)
         expect(person.actor_id).to eq(21731)
         expect(person.actor_name).to eq('Michael McKean')

--- a/spec/lib/tmdb/client_spec.rb
+++ b/spec/lib/tmdb/client_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Tmdb::Client do
       end
     end
 
-    describe '.person_detail_search' do
+    describe '.get_person_profile_data' do
       let(:person_id) { '2387' }
       let(:person_bio_data) do
         { name: 'Patrick Stewart',
@@ -434,12 +434,12 @@ RSpec.describe Tmdb::Client do
       end
 
       it 'returns a person_id' do
-        person = described_class.person_detail_search(person_id)
+        person = described_class.get_person_profile_data(person_id)
         expect(person.person_id).to eq(person_id)
       end
 
       it 'returns profile data' do
-        person = described_class.person_detail_search(person_id)
+        person = described_class.get_person_profile_data(person_id)
         expect(person.profile.person_id).to eq(person_id)
         expect(person.profile.name).to eq('Patrick Stewart')
         expect(person.profile.profile_path).to eq('/wEy5qSDT5jT3ZASc2hbwi59voPL.jpg')
@@ -448,7 +448,7 @@ RSpec.describe Tmdb::Client do
       end
 
       it 'returns movie credit data' do
-        person = described_class.person_detail_search(person_id)
+        person = described_class.get_person_profile_data(person_id)
         expect(person.movie_credits).to be_instance_of(MoviePersonCredits)
         expect(person.movie_credits.actor.first.character).to eq('Captain Jean-Luc Picard')
         expect(person.movie_credits.directing.first.title).to eq('Sleepwalk with Me')
@@ -459,7 +459,7 @@ RSpec.describe Tmdb::Client do
       end
 
       it 'returns tv credit data' do
-        person = described_class.person_detail_search(person_id)
+        person = described_class.get_person_profile_data(person_id)
         expect(person.tv_credits).to be_instance_of(TVPersonCredits)
         expect(person.tv_credits.actor.first.character).to eq('Self')
         expect(person.tv_credits.directing.first.show_name).to eq('Laverne & Shirley')

--- a/spec/lib/tmdb/client_spec.rb
+++ b/spec/lib/tmdb/client_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Tmdb::Client do
         ] } }
     end
 
-    describe '.movie_search' do
+    describe '.get_movie_search_results' do
       context 'when no results are found' do
         let(:searched_title) { 'kjdhfkgjfgh' }
         before do
@@ -40,22 +40,22 @@ RSpec.describe Tmdb::Client do
         end
 
         it 'returns the movie_title' do
-          results = described_class.movie_search(searched_title)
+          results = described_class.get_movie_search_results(searched_title)
           expect(results.movie_title).to eq(searched_title)
         end
 
         it 'returns an object with a not-found message' do
-          results = described_class.movie_search(searched_title)
+          results = described_class.get_movie_search_results(searched_title)
           expect(results.not_found_message).to eq("No results for 'kjdhfkgjfgh'.")
         end
 
         it 'returns the string that was queried' do
-          results = described_class.movie_search(searched_title)
+          results = described_class.get_movie_search_results(searched_title)
           expect(results.query).to eq('kjdhfkgjfgh')
         end
 
         it 'returns nil for movies' do
-          results = described_class.movie_search(searched_title)
+          results = described_class.get_movie_search_results(searched_title)
           expect(results.movies).to eq(nil)
         end
       end
@@ -99,17 +99,17 @@ RSpec.describe Tmdb::Client do
         end
 
         it 'returns the movie_title' do
-          results = described_class.movie_search(searched_title)
+          results = described_class.get_movie_search_results(searched_title)
           expect(results.movie_title).to eq(searched_title)
         end
 
         it 'returns a not_found mesage that is nil' do
-          results = described_class.movie_search(searched_title)
+          results = described_class.get_movie_search_results(searched_title)
           expect(results.not_found_message).to eq(nil)
         end
 
         it 'returns a list of movie objects' do
-          movies = described_class.movie_search(searched_title).movies
+          movies = described_class.get_movie_search_results(searched_title).movies
           expect(movies.first.title).to eq('Star Trek')
           expect(movies.second.title).to eq('Star Trek: Nemesis')
         end

--- a/spec/lib/tmdb/client_spec.rb
+++ b/spec/lib/tmdb/client_spec.rb
@@ -706,7 +706,7 @@ RSpec.describe Tmdb::Client do
       end
     end
 
-    describe '.tv_episode' do
+    describe '.get_tv_episode_data' do
       let(:tv_series) { build(:tv_series, show_id: 1) }
       let(:parsed_tv_episode_data) do
         {
@@ -732,7 +732,7 @@ RSpec.describe Tmdb::Client do
       end
       it 'returns a TVEpisode object with data' do
         allow(described_class).to receive(:request).and_return(parsed_tv_episode_data)
-        episode = described_class.tv_episode(series_id: tv_series.show_id, season_number: 'foo', episode_number: 'foo')
+        episode = described_class.get_tv_episode_data(series_id: tv_series.show_id, season_number: 'foo', episode_number: 'foo')
         expect(episode.episode_id).to eq(37107)
         expect(episode.episode_number).to eq(3)
         expect(episode.name).to eq('Brothers')

--- a/spec/lib/tmdb/client_spec.rb
+++ b/spec/lib/tmdb/client_spec.rb
@@ -539,7 +539,7 @@ RSpec.describe Tmdb::Client do
       end
     end
 
-    describe '.tv_series_autocomplete' do
+    describe '.get_tv_series_names' do
       let(:parsed_tv_search_results) do
         [{ id: 2382, name: 'Freaks and Geeks' },
          { id: 97018, name: 'Freaks!' }]
@@ -547,7 +547,7 @@ RSpec.describe Tmdb::Client do
 
       it 'returns a list of only Series names' do
         allow(described_class).to receive(:request).and_return(results: parsed_tv_search_results)
-        suggestions = described_class.tv_series_autocomplete('foo')
+        suggestions = described_class.get_tv_series_names('foo')
         expect(suggestions).to eq(['Freaks and Geeks', 'Freaks!'])
       end
     end

--- a/spec/lib/tmdb/client_spec.rb
+++ b/spec/lib/tmdb/client_spec.rb
@@ -125,28 +125,28 @@ RSpec.describe Tmdb::Client do
       end
     end
 
-    describe '.movie_cast' do
+    describe '.get_movie_cast' do
       before do
         allow(described_class).to receive(:request).and_return(parsed_movie_data)
       end
 
       it 'returns movie data' do
-        cast = described_class.movie_cast(movie_id)
+        cast = described_class.get_movie_cast(movie_id)
         expect(cast.movie.title).to eq('Serenity')
       end
 
       it 'returns actor data' do
-        cast = described_class.movie_cast(movie_id)
+        cast = described_class.get_movie_cast(movie_id)
         expect(cast.actors.first.name).to eq('Nathan Fillion')
       end
 
       it 'returns director data' do
-        cast = described_class.movie_cast(movie_id)
+        cast = described_class.get_movie_cast(movie_id)
         expect(cast.directors.first.name).to eq('Joss Whedon')
       end
 
       it 'returns editor data' do
-        cast = described_class.movie_cast(movie_id)
+        cast = described_class.get_movie_cast(movie_id)
         expect(cast.editors.first.name).to eq('Lisa Lassek')
       end
     end

--- a/spec/lib/tmdb/client_spec.rb
+++ b/spec/lib/tmdb/client_spec.rb
@@ -552,7 +552,7 @@ RSpec.describe Tmdb::Client do
       end
     end
 
-    describe '.tv_series_search' do
+    describe '.get_tv_series_search_results' do
       let(:parsed_tv_search_results) do
         [{
           backdrop_path: '/hpU2cHC9tk90hswCFEpf5AtbqoL.jpg',
@@ -574,7 +574,7 @@ RSpec.describe Tmdb::Client do
         allow(described_class).to receive(:request).and_return(results: parsed_tv_search_results)
       end
       it 'returns an array of TVSeries objects with data' do
-        series = described_class.tv_series_search('foo').first
+        series = described_class.get_tv_series_search_results('foo').first
         expect(series.show_id).to eq(456)
         expect(series.first_air_date).to eq('12/17/1989')
         expect(series.last_air_date).to eq(nil)


### PR DESCRIPTION
## Problems Solved
Related to Issue #288

Our goal with this work is to make the methods in our main API client more idiomatic for API-facing names. For example,  `movie_autocomplete` is the name of a feature in our application, but it is not what that client method does. The client method returns a list of movie titles based on a query. Calling our client method `get_movie_titles` is more appropriate because it is `get`ting to the API and returning a list of movie titles. 

I paired with @mikevallano on the concepts we wanted to use for these names.

We're hoping this rename will clarify the purpose of these methods and make it easier to understand the code more quickly at a glance.

We're implementing these kinds of changes in a series of small PRs to reduce risk and to make each PR easier to review.