### PR TITLE
Move update_movie out of Tmdb::Client

### DIFF
--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -39,7 +39,7 @@ class TmdbController < ApplicationController
     if params[:tmdb_id]
       @tmdb_id = params[:tmdb_id]
       movie = Movie.find_by!(tmdb_id: @tmdb_id)
-      Tmdb::Client.update_movie(movie)
+      MovieDataService.update_movie(movie)
     end
     redirect_to movie_more_path(tmdb_id: @tmdb_id)
   end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -16,35 +16,9 @@ class Movie < ActiveRecord::Base
   has_many :reviews
   has_many :ratings
   has_many :screenings
-  has_many :viewers, :through => :screenings,
-  :source => :user
+  has_many :viewers, :through => :screenings, :source => :user
 
   attr_accessor :production_companies
-
-  LIST_SORT_OPTIONS = [ ["title", "title"], ["shortest runtime", "shortest runtime"],
-  ["longest runtime", "longest runtime"], ["newest release", "newest release"],
-  ["vote average", "vote average"], ["recently added to list", "recently added to list"],
-  ["watched movies", "watched movies"], ["unwatched movies", "unwatched movies"],
-  ["recently watched", "recently watched"], ["highest priority", "highest priority"],
-  ["only show unwatched", "only show unwatched"], ["only show watched", "only show watched"] ]
-
-  MY_MOVIES_SORT_OPTIONS = [ ["title", "title"], ["shortest runtime", "shortest runtime"],
-  ["longest runtime", "longest runtime"], ["newest release", "newest release"],
-  ["vote average", "vote average"], ["watched movies", "watched movies"], ["recently watched", "recently watched"],
-  ["unwatched movies", "unwatched movies"], ["only show unwatched", "only show unwatched"],
-  ["only show watched", "only show watched"], ["movies not on a list", "movies not on a list"] ]
-
-  GENRES = [["Action", 28], ["Adventure", 12], ["Animation", 16], ["Comedy", 35], ["Crime", 80],
-  ["Documentary", 99], ["Drama", 18], ["Family", 10751], ["Fantasy", 14], ["Foreign", 10769], ["History", 36],
-  ["Horror", 27], ["Music", 10402], ["Mystery", 9648], ["Romance", 10749], ["Science Fiction", 878], ["TV Movie", 10770],
-  ["Thriller", 53], ["War", 10752], ["Western", 37]]
-
-  MPAA_RATINGS = [ ["R", "R"], ["NC-17", "NC-17"], ["PG-13", "PG-13"], ["G", "G"] ]
-
-  SORT_BY = [ ["Popularity", "popularity"], ["Release date", "release_date"], ["Revenue", "revenue"],
-  ["Vote average", "vote_average"], ["Vote count","vote_count"] ]
-
-  YEAR_SELECT = [ ["Exact Year", "exact"], ["After This Year", "after"], ["Before This Year", "before"] ]
 
   scope :by_title, -> { order(:title) }
   scope :by_shortest_runtime, -> { order(:runtime) }
@@ -83,7 +57,8 @@ class Movie < ActiveRecord::Base
     joins(:screenings).where(screenings: { user_id: user.id }).order("screenings.date_watched").reverse
   end
 
-  def in_db #since search results are treated as @movie instances, this determines a @movie is in the database
+  # Since search results are treated as @movie instances, this determines if a @movie is in the database
+  def in_db
     true
   end
 
@@ -126,8 +101,8 @@ class Movie < ActiveRecord::Base
   end
 
   def priority_text(list)
-    p = listings.find_by(list_id: list.id).priority
-    case p
+    priority = listings.find_by(list_id: list.id)&.priority
+    case priority
     when 1 then "Bottom"
     when 2 then "Low"
     when 3 then "Normal"

--- a/app/services/movie_data_service.rb
+++ b/app/services/movie_data_service.rb
@@ -26,4 +26,49 @@ module MovieDataService
 
   YEAR_SELECT = [ ["Exact Year", "exact"], ["After This Year", "after"], ["Before This Year", "before"] ]
 
+  def self.update_movie(movie)
+    # I'm not sure why this method uses HTTParty instead
+    tmdb_id = movie.tmdb_id.to_s
+    movie_url = "#{BASE_URL}/movie/#{tmdb_id}?api_key=#{API_KEY}&append_to_response=trailers,credits,releases"
+    api_result = begin
+                   HTTParty.get(movie_url).deep_symbolize_keys
+                 rescue StandardError
+                   nil
+                 end
+    raise Error, "API request failed for movie: #{movie.title}. tmdb_id: #{tmdb_id}" unless api_result
+
+    if api_result[:status_code] == 34 && api_result[:status_message]&.include?('could not be found')
+      puts "Movie not found, so not updated. Title: #{movie.title}. tmdb_id: #{tmdb_id}"
+      return
+    elsif api_result[:id]&.to_s != tmdb_id
+      raise Error, "API request failed for movie: #{movie.title}. tmdb_id: #{tmdb_id}"
+    end
+
+    updated_data = MovieMore.initialize_from_parsed_data(api_result)
+
+    if movie.title != updated_data.title
+      puts "Movie title doesn't match. tmdb_id: #{tmdb_id}. Current title: #{movie.title}. Title in TMDB: #{updated_data.title}"
+    end
+
+    movie.update!(
+      title: updated_data.title,
+      imdb_id: updated_data.imdb_id,
+      genres: updated_data.genres,
+      actors: updated_data.actors,
+      backdrop_path: updated_data.backdrop_path,
+      poster_path: updated_data.poster_path,
+      release_date: updated_data.release_date,
+      overview: updated_data.overview,
+      trailer: movie.trailer || updated_data.trailer,
+      director: updated_data.director,
+      director_id: updated_data.director_id,
+      vote_average: updated_data.vote_average,
+      popularity: updated_data.popularity,
+      runtime: updated_data.runtime,
+      mpaa_rating: updated_data.mpaa_rating,
+      updated_at: Time.current
+    )
+  rescue ActiveRecord::RecordInvalid => e
+    raise Error, "#{movie.title} failed update. #{e.message}"
+  end
 end

--- a/app/services/movie_data_service.rb
+++ b/app/services/movie_data_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module MovieDataService
+  LIST_SORT_OPTIONS = [ ["title", "title"], ["shortest runtime", "shortest runtime"],
+  ["longest runtime", "longest runtime"], ["newest release", "newest release"],
+  ["vote average", "vote average"], ["recently added to list", "recently added to list"],
+  ["watched movies", "watched movies"], ["unwatched movies", "unwatched movies"],
+  ["recently watched", "recently watched"], ["highest priority", "highest priority"],
+  ["only show unwatched", "only show unwatched"], ["only show watched", "only show watched"] ]
+
+  MY_MOVIES_SORT_OPTIONS = [ ["title", "title"], ["shortest runtime", "shortest runtime"],
+  ["longest runtime", "longest runtime"], ["newest release", "newest release"],
+  ["vote average", "vote average"], ["watched movies", "watched movies"], ["recently watched", "recently watched"],
+  ["unwatched movies", "unwatched movies"], ["only show unwatched", "only show unwatched"],
+  ["only show watched", "only show watched"], ["movies not on a list", "movies not on a list"] ]
+
+  GENRES = [["Action", 28], ["Adventure", 12], ["Animation", 16], ["Comedy", 35], ["Crime", 80],
+  ["Documentary", 99], ["Drama", 18], ["Family", 10751], ["Fantasy", 14], ["Foreign", 10769], ["History", 36],
+  ["Horror", 27], ["Music", 10402], ["Mystery", 9648], ["Romance", 10749], ["Science Fiction", 878], ["TV Movie", 10770],
+  ["Thriller", 53], ["War", 10752], ["Western", 37]]
+
+  MPAA_RATINGS = [ ["R", "R"], ["NC-17", "NC-17"], ["PG-13", "PG-13"], ["G", "G"] ]
+
+  SORT_BY = [ ["Popularity", "popularity"], ["Release date", "release_date"], ["Revenue", "revenue"],
+  ["Vote average", "vote_average"], ["Vote count","vote_count"] ]
+
+  YEAR_SELECT = [ ["Exact Year", "exact"], ["After This Year", "after"], ["Before This Year", "before"] ]
+
+end

--- a/app/services/movie_data_service.rb
+++ b/app/services/movie_data_service.rb
@@ -29,7 +29,7 @@ module MovieDataService
   def self.update_movie(movie)
     # I'm not sure why this method uses HTTParty instead
     tmdb_id = movie.tmdb_id.to_s
-    movie_url = "#{BASE_URL}/movie/#{tmdb_id}?api_key=#{API_KEY}&append_to_response=trailers,credits,releases"
+    movie_url = "#{Tmdb::Client::BASE_URL}/movie/#{tmdb_id}?api_key=#{Tmdb::Client::API_KEY}&append_to_response=trailers,credits,releases"
     api_result = begin
                    HTTParty.get(movie_url).deep_symbolize_keys
                  rescue StandardError

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -10,7 +10,7 @@
 
 
   <%= form_tag user_list_path(@list.owner, @list), { class: "form-class", id: "list-show-sort", role: "form", method: :get } do %>
-    <%= select_tag :sort_by, options_for_select(Movie::LIST_SORT_OPTIONS, @sort_by), { class: "form-control index-sort-dropdown", :include_blank => "Sort by", id: "list_sort_options" } %>
+    <%= select_tag :sort_by, options_for_select(MovieDataService::LIST_SORT_OPTIONS, @sort_by), { class: "form-control index-sort-dropdown", :include_blank => "Sort by", id: "list_sort_options" } %>
     <%= submit_tag "Sort", id: "list_sort_button" %>
   <% end %>
   <br>

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -1,13 +1,12 @@
 <% content_for(:title, @list.name) %>
+
 <div class="row">
+  <h1><%= @list.name %> <span class="count">(<%= pluralize(@list.movies.size, "Movie") %>) <icon class="<%= public_private_indicator(@list) %>"><icon></span></h1>
+  <p>by <%= @list.owner.username %></p>
 
-<h1><%= @list.name %> <span class="count">(<%= pluralize(@list.movies.size, "Movie") %>) <icon class="<%= public_private_indicator(@list) %>"><icon></span></h1>
-<p>by <%= @list.owner.username %></p>
-
-<% if @list.description.present? %>
-  <p><%= @list.description %></p>
-<% end %> <!-- #if description.present -->
-
+  <% if @list.description.present? %>
+    <p><%= @list.description %></p>
+  <% end %> <!-- #if description.present -->
 
   <%= form_tag user_list_path(@list.owner, @list), { class: "form-class", id: "list-show-sort", role: "form", method: :get } do %>
     <%= select_tag :sort_by, options_for_select(MovieDataService::LIST_SORT_OPTIONS, @sort_by), { class: "form-control index-sort-dropdown", :include_blank => "Sort by", id: "list_sort_options" } %>
@@ -15,26 +14,23 @@
   <% end %>
   <br>
 
-<% if @sort_by.present? && @list.members.present? && @watched_sorts.include?(@sort_by) %>
-
-  <%= form_tag user_list_path(@list.owner, @list), { class: "form-class", id: "list-show-member-sort", role: "form", method: :get } do %>
-    <%= select_tag :member, options_from_collection_for_select(@list.members, :id, :username, @member), { class: "form-control index-sort-dropdown", :include_blank => "By which member?: " } %>
-    <%= hidden_field_tag(:sort_by, @sort_by) %>
-    <%= submit_tag "Sort", id: "list_sort_watched_by_button" %>
-  <% end %>
-
-<% end %> <!-- # if @sort_by = "watched movies" && @list.members.present? -->
-
+  <% if @sort_by.present? && @list.members.present? && @watched_sorts.include?(@sort_by) %>
+    <%= form_tag user_list_path(@list.owner, @list), { class: "form-class", id: "list-show-member-sort", role: "form", method: :get } do %>
+      <%= select_tag :member, options_from_collection_for_select(@list.members, :id, :username, @member), { class: "form-control index-sort-dropdown", :include_blank => "By which member?: " } %>
+      <%= hidden_field_tag(:sort_by, @sort_by) %>
+      <%= submit_tag "Sort", id: "list_sort_watched_by_button" %>
+    <% end %>
+  <% end %> <!-- # if @sort_by = "watched movies" && @list.members.present? -->
 </div> <!-- row -->
 
-  <div id ="list_show_loop">
-    <%= render partial: 'movies/movie_partial_loop', locals: { movies: @movies, list: @list } %>
-  </div>
+<div id ="list_show_loop">
+  <%= render partial: 'movies/movie_partial_loop', locals: { movies: @movies, list: @list } %>
+</div>
 
-  <div class="row tile-container">
-     <center>
-      <div class="pagination">
-        <p><%= will_paginate @movies %></p>
-      </div><!-- pagination -->
-    </center>
-  </div>
+<div class="row tile-container">
+   <center>
+    <div class="pagination">
+      <p><%= will_paginate @movies %></p>
+    </div><!-- pagination -->
+  </center>
+</div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -21,7 +21,7 @@
   <% unless @tag.present? || @genre.present? %> <!-- # hide sort form if already sorted by tag or genre -->
 
     <%= form_tag movies_path, { class: "form-class", id: "movies-index-sort", role: "form", method: :get } do %>
-      <%= select_tag :sort_by, options_for_select(Movie::MY_MOVIES_SORT_OPTIONS, @sort_by), {:prompt => "Sort by...", class: "form-control index-sort-dropdown", :include_blank => false, id: "list_sort_options" } %>
+      <%= select_tag :sort_by, options_for_select(MovieDataService::MY_MOVIES_SORT_OPTIONS, @sort_by), {:prompt => "Sort by...", class: "form-control index-sort-dropdown", :include_blank => false, id: "list_sort_options" } %>
       <%= submit_tag "Sort", id: "sort_button_movies_index", class: "form-control-submit" %>
     <% end %>
   <% end %>

--- a/app/views/tmdb/actor_search.html.erb
+++ b/app/views/tmdb/actor_search.html.erb
@@ -4,7 +4,7 @@
 <% if @results&.actor.blank? %> <!-- Display the search form -->
   <%= form_tag '/tmdb/actor_search', { class: "form-class", id: "actor-search", role: "form", method: :get } do %>
     <%= text_field_tag :actor, nil, class: "form-control search-form autocomplete-search-field", id: "actor_name_actor_search", placeholder: "Enter Actor Name", data: { autocomplete_source: person_autocomplete_path } %>
-    <%= select_tag :sort_by, options_for_select(Movie::SORT_BY), {:prompt => "Sort by...", class: "form-control search-form", :include_blank => false } %>
+    <%= select_tag :sort_by, options_for_select(MovieDataService::SORT_BY), {:prompt => "Sort by...", class: "form-control search-form", :include_blank => false } %>
     <%= submit_tag "Search", id: "submit_button_actor_search", class: "form-control-submit search-form-submit" %>
   <% end %>
 <% end %>

--- a/app/views/tmdb/discover_search.html.erb
+++ b/app/views/tmdb/discover_search.html.erb
@@ -7,7 +7,7 @@
   <%= form_tag '/tmdb/discover_search', { class: 'form-class', id: 'discover-search', role: 'form', method: :get } do %>
     <div class="row">
       <%= text_field_tag :actor_name, nil, class: "form-control search-form autocomplete-search-field", id: "actor_name_field_discover_search", placeholder: "Enter Actor Name", data: { autocomplete_source: person_autocomplete_path } %>
-      <%= select_tag :genre, options_for_select(Movie::GENRES), { class: "form-control search-form", id: "genre_field_discover_search", include_blank: "Pick a genre" } %><br>
+      <%= select_tag :genre, options_for_select(MovieDataService::GENRES), { class: "form-control search-form", id: "genre_field_discover_search", include_blank: "Pick a genre" } %><br>
       <%= select_year(0,
       { prompt: "Enter a year", start_year: DateTime.now.year, end_year: DateTime.now.year - 100 },
       { field_name: :year,
@@ -15,9 +15,9 @@
         id: "year_field_discover_search",
         class: "form-control search-form" }
         )%>
-        <%= select_tag :timeframe, options_for_select(Movie::YEAR_SELECT), { class: "form-control search-form", id: "year_select_discover_search", include_blank: "Year select" } %><br>
-        <%= select_tag :mpaa_rating, options_for_select(Movie::MPAA_RATINGS), { class: "form-control search-form", id: "mpaa_field_discover_search", include_blank: "Pick a rating" } %><br>
-        <%= select_tag :sort_by, options_for_select(Movie::SORT_BY), { class: "form-control search-form", id: "sort_by_discover_search", include_blank: "Sort by" } %>
+        <%= select_tag :timeframe, options_for_select(MovieDataService::YEAR_SELECT), { class: "form-control search-form", id: "year_select_discover_search", include_blank: "Year select" } %><br>
+        <%= select_tag :mpaa_rating, options_for_select(MovieDataService::MPAA_RATINGS), { class: "form-control search-form", id: "mpaa_field_discover_search", include_blank: "Pick a rating" } %><br>
+        <%= select_tag :sort_by, options_for_select(MovieDataService::SORT_BY), { class: "form-control search-form", id: "sort_by_discover_search", include_blank: "Sort by" } %>
     </div>
     <div class="row">
       <p><%= submit_tag "Search", id: "search_button_discover_search", class: "form-control-submit search-form-submit" %></p>

--- a/lib/search_param_parser.rb
+++ b/lib/search_param_parser.rb
@@ -24,7 +24,7 @@ module SearchParamParser
     output[:mpaa_rating_display] = "Rated #{params[:mpaa_rating]}" if params[:mpaa_rating].present?
 
     if params[:genre].present?
-      genres = Movie::GENRES.to_h
+      genres = MovieDataService::GENRES.to_h
       genre_selected = genres.key(params[:genre].to_i)
       output[:genre_display] = "#{genre_selected} movies"
     end
@@ -40,7 +40,7 @@ module SearchParamParser
     end
 
     if params[:sort_by].present?
-      sort_options = Movie::SORT_BY.to_h
+      sort_options = MovieDataService::SORT_BY.to_h
       sort_key = sort_options.key(params[:sort_by])
       output[:sort_display] = "sorted by #{sort_key}"
     end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -16,7 +16,7 @@ namespace :tmdb_data do
     updated_movies = []
 
     movies.each do |movie|
-      Tmdb::Client.update_movie(movie)
+      MovieDataService.update_movie(movie)
       puts "Movie refreshed. #{movie.title}. tmdb_id: #{movie.tmdb_id}"
       updated_movies << movie.tmdb_id
       sleep 0.01

--- a/lib/tmdb/client.rb
+++ b/lib/tmdb/client.rb
@@ -117,53 +117,6 @@ module Tmdb
         data.map { |d| d[:title] }.uniq
       end
 
-      # TODO: Move this to the Movie class as update_with_api_data
-      def update_movie(movie)
-        # I'm not sure why this method uses HTTParty instead
-        tmdb_id = movie.tmdb_id.to_s
-        movie_url = "#{BASE_URL}/movie/#{tmdb_id}?api_key=#{API_KEY}&append_to_response=trailers,credits,releases"
-        api_result = begin
-                       HTTParty.get(movie_url).deep_symbolize_keys
-                     rescue StandardError
-                       nil
-                     end
-        raise Error, "API request failed for movie: #{movie.title}. tmdb_id: #{tmdb_id}" unless api_result
-
-        if api_result[:status_code] == 34 && api_result[:status_message]&.include?('could not be found')
-          puts "Movie not found, so not updated. Title: #{movie.title}. tmdb_id: #{tmdb_id}"
-          return
-        elsif api_result[:id]&.to_s != tmdb_id
-          raise Error, "API request failed for movie: #{movie.title}. tmdb_id: #{tmdb_id}"
-        end
-
-        updated_data = MovieMore.initialize_from_parsed_data(api_result)
-
-        if movie.title != updated_data.title
-          puts "Movie title doesn't match. tmdb_id: #{tmdb_id}. Current title: #{movie.title}. Title in TMDB: #{updated_data.title}"
-        end
-
-        movie.update!(
-          title: updated_data.title,
-          imdb_id: updated_data.imdb_id,
-          genres: updated_data.genres,
-          actors: updated_data.actors,
-          backdrop_path: updated_data.backdrop_path,
-          poster_path: updated_data.poster_path,
-          release_date: updated_data.release_date,
-          overview: updated_data.overview,
-          trailer: movie.trailer || updated_data.trailer,
-          director: updated_data.director,
-          director_id: updated_data.director_id,
-          vote_average: updated_data.vote_average,
-          popularity: updated_data.popularity,
-          runtime: updated_data.runtime,
-          mpaa_rating: updated_data.mpaa_rating,
-          updated_at: Time.current
-        )
-      rescue ActiveRecord::RecordInvalid => e
-        raise Error, "#{movie.title} failed update. #{e.message}"
-      end
-
       def get_common_actors_between_movies(movie_one_title, movie_two_title)
         movie_one_results = get_movie_title_search_results(movie_one_title)
         movie_two_results = get_movie_title_search_results(movie_two_title)

--- a/spec/lib/search_param_parser_spec.rb
+++ b/spec/lib/search_param_parser_spec.rb
@@ -55,7 +55,7 @@ describe SearchParamParser do
     end
 
     context 'genre_display' do
-      before { stub_const('Movie::GENRES', GENRES = [['Cat', 42]].freeze) }
+      before { stub_const('MovieDataService::GENRES', GENRES = [['Cat', 42]].freeze) }
       context 'when genre is present' do
         it 'sets the genre_display to a genre name' do
           result = described_class.parse_movie_params_for_display(genre: 42)
@@ -88,7 +88,7 @@ describe SearchParamParser do
     end
 
     context 'sort_display' do
-      before { stub_const('Movie::SORT_BY', SORT_BY = [['Fancy Foo', 'foo']].freeze) }
+      before { stub_const('MovieDataService::SORT_BY', SORT_BY = [['Fancy Foo', 'foo']].freeze) }
       context 'when sort_by is present' do
         it 'sets the sort_display to a sorting option name' do
           result = described_class.parse_movie_params_for_display(sort_by: 'foo')

--- a/spec/lib/tmdb/client_spec.rb
+++ b/spec/lib/tmdb/client_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Tmdb::Client do
 
       context 'when no movies matches are found' do
         it 'returns a not-found message about all of the searched terms' do
-          stub_const('Movie::GENRES', GENRES = [['foo', 42]].freeze)
+          stub_const('MovieDataService::GENRES', GENRES = [['foo', 42]].freeze)
           allow(described_class).to receive(:request).with(:discover_search, genre: 42).and_return(results: [])
           result = described_class.get_advanced_movie_search_results(genre: 42)
           expect(result.not_found_message).to eq('No results for foo movies.')
@@ -218,8 +218,8 @@ RSpec.describe Tmdb::Client do
           end
 
           it 'returns the searched terms in a human-readable format' do
-            stub_const('Movie::GENRES', GENRES = [['Action', 42]].freeze)
-            stub_const('Movie::SORT_BY', SORT_BY = [['Revenue', 45]].freeze)
+            stub_const('MovieDataService::GENRES', GENRES = [['Action', 42]].freeze)
+            stub_const('MovieDataService::SORT_BY', SORT_BY = [['Revenue', 45]].freeze)
             results = described_class.get_advanced_movie_search_results(params)
             expect(results.searched_terms).to eq('Jeff movies, Rated R, Action movies, after 1990, sorted by Revenue')
           end
@@ -379,62 +379,6 @@ RSpec.describe Tmdb::Client do
         allow(described_class).to receive(:request).and_return(results: parsed_data)
         names = described_class.get_movie_titles("doesn't matter")
         expect(names).to eq(%w[A B C])
-      end
-    end
-
-    describe '.update_movie' do
-      let(:movie) { create(:movie_in_tmdb) }
-      let(:tmdb_id) { movie.tmdb_id }
-      subject { Tmdb::Client.update_movie(movie) }
-
-      context 'with a valid movie' do
-        it 'returns true' do
-          VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie') do
-            expect(subject).to eq(true)
-          end
-        end
-
-        it 'updates the movie' do
-          VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie') do
-            expect { subject }.to(change { movie.reload.updated_at })
-          end
-        end
-      end
-
-      context 'when no movie found from api response' do
-        before { movie.update(tmdb_id: 'wrong') }
-        it 'raises an error and does not update the movie' do
-          VCR.use_cassette('tmdb_handler_update_movie_with_an_invalid_movie') do
-            expect { subject }.not_to(change { movie.reload.updated_at })
-          end
-        end
-      end
-
-      context 'when the title does not match' do
-        before { movie.update(title: 'Fargowrong') }
-        it 'does not raise an error' do
-          VCR.use_cassette('tmdb_handler_update_movie_with_wrong_title') do
-            expect { subject }.not_to raise_error
-          end
-        end
-
-        it 'still updates the movie' do
-          VCR.use_cassette('tmdb_handler_update_movie_with_wrong_title') do
-            expect { subject }.to(change { movie.reload.updated_at })
-          end
-        end
-      end
-
-      context 'with outdated info' do
-        let(:wrong_mpaa_rating) { 'G' }
-        let(:correct_mpaa_rating) { 'R' }
-        before { movie.update(mpaa_rating: wrong_mpaa_rating) }
-        it 'updates movie with latest tmdb info' do
-          VCR.use_cassette('tmdb_handler_update_movie_with_outdated_info') do
-            subject
-            expect(movie.reload.mpaa_rating).to eq(correct_mpaa_rating)
-          end
-        end
       end
     end
 

--- a/spec/services/movie_data_service_spec.rb
+++ b/spec/services/movie_data_service_spec.rb
@@ -59,4 +59,4 @@ RSpec.describe MovieDataService do
       end
     end
   end
-end`
+end

--- a/spec/services/movie_data_service_spec.rb
+++ b/spec/services/movie_data_service_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MovieDataService do
+
+  describe '.update_movie' do
+    let(:movie) { create(:movie_in_tmdb) }
+    let(:tmdb_id) { movie.tmdb_id }
+    subject { MovieDataService.update_movie(movie) }
+
+    context 'with a valid movie' do
+      it 'returns true' do
+        VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie') do
+          expect(subject).to eq(true)
+        end
+      end
+
+      it 'updates the movie' do
+        VCR.use_cassette('tmdb_handler_update_movie_with_a_valid_movie') do
+          expect { subject }.to(change { movie.reload.updated_at })
+        end
+      end
+    end
+
+    context 'when no movie found from api response' do
+      before { movie.update(tmdb_id: 'wrong') }
+      it 'raises an error and does not update the movie' do
+        VCR.use_cassette('tmdb_handler_update_movie_with_an_invalid_movie') do
+          expect { subject }.not_to(change { movie.reload.updated_at })
+        end
+      end
+    end
+
+    context 'when the title does not match' do
+      before { movie.update(title: 'Fargowrong') }
+      it 'does not raise an error' do
+        VCR.use_cassette('tmdb_handler_update_movie_with_wrong_title') do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      it 'still updates the movie' do
+        VCR.use_cassette('tmdb_handler_update_movie_with_wrong_title') do
+          expect { subject }.to(change { movie.reload.updated_at })
+        end
+      end
+    end
+
+    context 'with outdated info' do
+      let(:wrong_mpaa_rating) { 'G' }
+      let(:correct_mpaa_rating) { 'R' }
+      before { movie.update(mpaa_rating: wrong_mpaa_rating) }
+      it 'updates movie with latest tmdb info' do
+        VCR.use_cassette('tmdb_handler_update_movie_with_outdated_info') do
+          subject
+          expect(movie.reload.mpaa_rating).to eq(correct_mpaa_rating)
+        end
+      end
+    end
+  end
+end`


### PR DESCRIPTION
## Related Issues & PRs
* Relates to #294
* Relates to #297 

## Problems Solved
@mikevallano and I have been talking about how the `update_movie` didn't belong in the `Tmdb::Client` since it deals with managing an active record object. It also didn't really belong in the `Movie` model since it reaches beyond the scope of active record object itself (#294). It is a hybrid method that needs some kind of service.

We've also been talking about making our 🔥 new `Tmdb::Client` much skinnier (#297) -- housing only the `request` method and moving the `get_movie_titles...` type of methods into a data service of some sort.

This PR starts that process. 
* introduce a new `MovieDataService` object
* move `update_movie` into it
* move large arrays that are meant to help with form submissions (sorting options, genres, etc) from the `Movie` model into the `MovieDataService` object.

Future work I think will look like:
* moving other `get_movie...` methods from `Tmdb::Client` to `MovieDataService`
* moving TV-related methods from `Tmdb::Client` to `TvDataService`
* moving person-related methods from `Tmdb::Client` to `PersonDataService`