### PR TITLE
Update Devise test helper

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -51,7 +51,7 @@ Capybara.javascript_driver = :selenium_chrome_headless
 RSpec::Matchers.define_negated_matcher :not_change, :change
 
 RSpec.configure do |config|
-  config.include Devise::TestHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Warden::Test::Helpers
   config.include ControllerHelpers, type: :controller
   config.include FeatureHelpers, type: :feature


### PR DESCRIPTION
## Related Issues & PRs
Closes #303

Resolves this spec error output:
```
DEPRECATION WARNING: [Devise] including `Devise::TestHelpers` is deprecated and will be removed from Devise.
For controller tests, please include `Devise::Test::ControllerHelpers` instead.
```
