### PR TITLE
Search for frequent actors in a director's movies

### DIFF
--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -132,6 +132,12 @@ class TmdbController < ApplicationController
     end
   end
 
+  def director_common_actors
+    if params[:director_name]
+      @results = MovieDataService.get_common_actors_for_director(params[:director_name])
+    end
+  end
+
   def discover_search
     form_params = %i[sort_by date year genre actor_name company mpaa_rating timeframe page]
     passed_params = params.slice(*form_params).select { |_k, v| v.present? }

--- a/app/services/movie_data_service.rb
+++ b/app/services/movie_data_service.rb
@@ -249,5 +249,56 @@ module MovieDataService
         total_pages: movie_response[:total_pages]
       )
     end
+
+    def get_common_actors_for_director(director_name)
+      person_data = Tmdb::Client.request(:person_search, query: director_name)[:results]&.first
+      # person_data.keys
+      # [:adult, :gender, :id, :known_for, :known_for_department, :name, :popularity, :profile_path]
+      # id: 7399, name: 'Ben Stiller'
+      if person_data.blank?
+        return OpenStruct.new(
+          not_found_message: "No directors found for '#{director_name}'."
+        )
+      end
+
+      person_credits = Tmdb::Client.request(:person_movie_credits, person_id: person_data[:id])
+      # person_credits.keys => [:cast, :crew, :id]
+      movie_ids = person_credits[:crew].select { |crew| crew[:job] == 'Director' }.map { |movie| movie[:id] }
+      # movie_ids = [movie_ids.first]
+      actors = {}
+      movie_ids.each do |id|
+        movie_credits = Tmdb::Client.request(:movie_data, movie_id: id)
+        cast_members = movie_credits.dig(:credits, :cast).map {|cast| cast[:name] }
+# binding.pry
+        cast_members.each do |person|
+          if actors[person].present?
+            actors[person] += 1
+          else
+            actors[person] = 1
+          end
+        end
+      end
+
+      actors.select { |k, v| v > 1 }.sort_by { |k, v| -v }.to_h
+
+      binding.pry
+
+
+      # total_pages = movie_data&.fetch(:total_pages).zero? ? 1 : movie_data&.fetch(:total_pages)
+      # not_found_message = "No movies found for '#{director_name}'." if movie_results.blank?
+      # current_page = movie_data[:page]
+      #
+      # OpenStruct.new(
+      #   id: person_data[:id],
+      #   actor: person_data,
+      #   actor_name: person_data[:name],
+      #   movies: MovieSearch.parse_results(movie_results),
+      #   not_found_message: not_found_message,
+      #   current_page: current_page,
+      #   previous_page: (current_page - 1 if current_page > 1),
+      #   next_page: (current_page + 1 unless current_page >= total_pages),
+      #   total_pages: total_pages
+      # )
+    end
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -58,6 +58,7 @@
             <li role="separator" class="divider"></li>
             <li><%= link_to "Common Movies Between 2 Actors", two_actor_search_path %></li>
             <li><%= link_to "Common Actors Between 2 Movies", two_movie_search_path %></li>
+            <li><%= link_to "Frequent Actors in a Director's Movies", director_common_actors_path %></li>
 
           </ul><!-- Search dropdown items -->
         </li><!-- Search dropdown button -->

--- a/app/views/tmdb/director_common_actors.html.erb
+++ b/app/views/tmdb/director_common_actors.html.erb
@@ -13,14 +13,14 @@
     <p> Check your spelling and try again.</p>
 
   <% else %> <!-- movies were found -->
-    <h2><%= link_to "#{@results.movie_one.title}", movie_more_path(tmdb_id: @results.movie_one.tmdb_id) %> and <%= link_to "#{@results.movie_two.title}", movie_more_path(tmdb_id: @results.movie_two.tmdb_id) %> have <%= pluralize(@results.common_actors.size, "actor") %> in common:</h2>
+    <h2><%= @results.director_name %> has directed <%= @results.movies_count %> movies and these actors have been in at least <%= @results.minimum_movie_count %> of them:</h2>
     <ul>
-      <% @results.common_actors.each do |actor| %>
-        <li><%= link_to "#{actor}", actor_search_path(actor: I18n.transliterate(actor)) %></li>
+      <% @results.actors.each do |actor| %>
+        <li><%= link_to "#{actor.name}", actor_more_path(actor_id: actor.id) %> (<%= actor.count %>)</li>
       <% end %>
     </ul>
     <br>
   <% end %>
 
-  <p class="button-main"><%= link_to "Search Again", director_common_actors %> </p>
+  <p class="button-main"><%= link_to "Search Again", director_common_actors_path %> </p>
 <% end %>

--- a/app/views/tmdb/director_common_actors.html.erb
+++ b/app/views/tmdb/director_common_actors.html.erb
@@ -1,0 +1,26 @@
+<h1>Common Actors in a Director's Movies</h1>
+
+<% if @results.nil? %>
+  <p>Enter a director name to find out what actors frequently appear in their films.</p>
+  <%= form_tag '/tmdb/director_common_actors', { class: "form-class", id: "director-common-actors", role: "form", method: :get } do %>
+  <%= text_field_tag :director_name, nil, class: "form-control search-form autocomplete-search-field", id: "director_name_field", placeholder: "Enter a director's name", data: { autocomplete_source: person_autocomplete_path } %>
+  <%= submit_tag "Search", id: "foo", class: "form-control-submit search-form-submit" %>
+  <% end %>
+
+<% else %><!-- a search has been made -->
+  <% if @results.not_found_message.present? %>
+    <h2>Hmm. <%= @results.not_found_message %></h2>
+    <p> Check your spelling and try again.</p>
+
+  <% else %> <!-- movies were found -->
+    <h2><%= link_to "#{@results.movie_one.title}", movie_more_path(tmdb_id: @results.movie_one.tmdb_id) %> and <%= link_to "#{@results.movie_two.title}", movie_more_path(tmdb_id: @results.movie_two.tmdb_id) %> have <%= pluralize(@results.common_actors.size, "actor") %> in common:</h2>
+    <ul>
+      <% @results.common_actors.each do |actor| %>
+        <li><%= link_to "#{actor}", actor_search_path(actor: I18n.transliterate(actor)) %></li>
+      <% end %>
+    </ul>
+    <br>
+  <% end %>
+
+  <p class="button-main"><%= link_to "Search Again", director_common_actors %> </p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
   get 'tmdb/actor_credit', to: 'tmdb#actor_credit', as: :actor_credit
   get 'tmdb/two_actor_search', to: 'tmdb#two_actor_search', as: :two_actor_search
   get 'tmdb/director_search', to: 'tmdb#director_search', as: :director_search
+  get 'tmdb/director_common_actors', to: 'tmdb#director_common_actors', as: :director_common_actors
   get 'tmdb/tv_episode', to: 'tmdb#tv_episode', as: :tv_episode
   get 'tmdb/tv_series', to: 'tmdb#tv_series', as: :tv_series
   get 'tmdb/tv_series_search', to: 'tmdb#tv_series_search', as: :tv_series_search


### PR DESCRIPTION
## Related Issues & PRs
Closes #306

## Problems Solved
Some directors have the same actors in their movies over and over again. I was curious about some of these trends, so I built this page. The hard part is that it is not performant _at all_. This MVP version makes these API calls:
* autocomplete (many) to get director name
* person search to get their id
* movie credits to get a list of movie ids
* movie data _for each movie id_ to get the actors

For a director with 30 movies, that's over 30 API calls. Yikes.

## Screenshots
<img width="915" alt="Screen Shot 2022-03-14 at 6 46 21 PM" src="https://user-images.githubusercontent.com/8680712/158278936-6a552844-6585-464e-b4d0-b5a6245514ff.png">

## Things Learned
* 🤔 
