### PR TITLE
Add seen movies section to actor more page

### DIFF
--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -77,7 +77,10 @@ class TmdbController < ApplicationController
   end
 
   def actor_more
-    @actor = PersonDataService.get_person_profile_data(params[:actor_id])
+    @results = OpenStruct.new(
+      actor: PersonDataService.get_person_profile_data(params[:actor_id]),
+      movies_seen: current_user.watched_movies.pluck(:tmdb_id)
+    )
   end
 
   def actor_credit

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -77,9 +77,13 @@ class TmdbController < ApplicationController
   end
 
   def actor_more
-    @results = OpenStruct.new(
-      actor: PersonDataService.get_person_profile_data(params[:actor_id]),
-      movies_seen: current_user.watched_movies.pluck(:tmdb_id)
+    actor_data = PersonDataService.get_person_profile_data(params[:actor_id])
+    movies_seen = current_user.watched_movies.pluck(:tmdb_id)
+    actor_movies_seen = actor_data.movie_credits.actor.select { |m| movies_seen.include?(m.tmdb_id) }
+
+    @data = OpenStruct.new(
+      actor: actor_data,
+      movies_seen: actor_movies_seen
     )
   end
 
@@ -130,9 +134,7 @@ class TmdbController < ApplicationController
   end
 
   def director_search
-    if params[:director_id]
-      @director = PersonDataService.get_person_profile_data(params[:director_id])
-    end
+    @director = PersonDataService.get_person_profile_data(params[:director_id]) if params[:director_id]
   end
 
   def discover_search

--- a/app/views/tmdb/_seen_movie_credits.html.erb
+++ b/app/views/tmdb/_seen_movie_credits.html.erb
@@ -1,5 +1,5 @@
 <h3>
-  Movie's I've Seen
+  Movies I've Seen
 </h3>
 <ul>
   <% movie_credits.actor.each do |credit| %>

--- a/app/views/tmdb/_seen_movie_credits.html.erb
+++ b/app/views/tmdb/_seen_movie_credits.html.erb
@@ -1,9 +1,9 @@
-<h3>
-  Movies I've Seen
-</h3>
-<ul>
-  <% movie_credits.actor.each do |credit| %>
-    <% if movies_seen.include?(credit.tmdb_id) %>
+<% if movies_seen.any? %>
+  <h3>
+    Movies I've Seen
+  </h3>
+  <ul>
+    <% movies_seen.each do |credit| %>
       <li>
         <%= link_to credit.title, movie_more_path(tmdb_id: "#{credit.tmdb_id}") %>
         <%= "| #{credit.date}" if credit.date != "Date unavailable" %>
@@ -11,5 +11,5 @@
         <%= "as #{credit.character}" if credit.character.present? %>
       </li>
     <% end %>
-  <% end %>
-</ul>
+  </ul>
+<% end %>

--- a/app/views/tmdb/_seen_movie_credits.html.erb
+++ b/app/views/tmdb/_seen_movie_credits.html.erb
@@ -1,0 +1,15 @@
+<h3>
+  Movie's I've Seen
+</h3>
+<ul>
+  <% movie_credits.actor.each do |credit| %>
+    <% if movies_seen.include?(credit.tmdb_id) %>
+      <li>
+        <%= link_to credit.title, movie_more_path(tmdb_id: "#{credit.tmdb_id}") %>
+        <%= "| #{credit.date}" if credit.date != "Date unavailable" %>
+        <%= display_actor_age_at_release(person_profile.birthday, credit.date) %>
+        <%= "as #{credit.character}" if credit.character.present? %>
+      </li>
+    <% end %>
+  <% end %>
+</ul>

--- a/app/views/tmdb/actor_more.html.erb
+++ b/app/views/tmdb/actor_more.html.erb
@@ -1,30 +1,32 @@
 <article id="profile">
   <div class="row">
     <div class="summary-box">
-      <%= image_tag(TmdbImageService.image_url(file_path: @actor.profile.profile_path, size: :medium, image_type: :profile)) %>
+      <%= image_tag(TmdbImageService.image_url(file_path: @results.actor.profile.profile_path, size: :medium, image_type: :profile)) %>
       <div class="contents">
-        <h1><%= @actor.profile.name %></h1>
-        <h2>Born: <%= display_birthday_info(@actor.profile) %></h2>
-        <p class="bio"><%= @actor.profile.bio %></p>
+        <h1><%= @results.actor.profile.name %></h1>
+        <h2>Born: <%= display_birthday_info(@results.actor.profile) %></h2>
+        <p class="bio"><%= @results.actor.profile.bio %></p>
       </div> <!-- contents -->
     </div> <!-- summary-box -->
   </div> <!-- row -->
 
   <div class="row">
     <div class="credits">
-      <%= render partial: "movie_credits", locals: { person_profile: @actor.profile, movie_credits: @actor.movie_credits } %>
+      <%= render partial: "movie_credits", locals: { person_profile: @results.actor.profile, movie_credits: @results.actor.movie_credits } %>
 
-      <%= render partial: "tv_credits", locals: { tv_credits: @actor.tv_credits, actor_id: @actor.person_id }  %>
+      <%= render partial: "seen_movie_credits", locals: { person_profile: @results.actor.profile, movie_credits: @results.actor.movie_credits, movies_seen: @results.movies_seen } %>
 
-      <%= render partial: "director_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
+      <%= render partial: "tv_credits", locals: { tv_credits: @results.actor.tv_credits, actor_id: @results.actor.person_id }  %>
 
-      <%= render partial: "producer_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
+      <%= render partial: "director_credits", locals: { movie_credits: @results.actor.movie_credits, tv_credits: @results.actor.tv_credits }  %>
 
-      <%= render partial: "editor_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
+      <%= render partial: "producer_credits", locals: { movie_credits: @results.actor.movie_credits, tv_credits: @results.actor.tv_credits }  %>
 
-      <%= render partial: "writer_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
+      <%= render partial: "editor_credits", locals: { movie_credits: @results.actor.movie_credits, tv_credits: @results.actor.tv_credits }  %>
 
-      <%= render partial: "screenplay_credits", locals: { movie_credits: @actor.movie_credits, tv_credits: @actor.tv_credits }  %>
+      <%= render partial: "writer_credits", locals: { movie_credits: @results.actor.movie_credits, tv_credits: @results.actor.tv_credits }  %>
+
+      <%= render partial: "screenplay_credits", locals: { movie_credits: @results.actor.movie_credits, tv_credits: @results.actor.tv_credits }  %>
     </div>
   </div>
 </article>

--- a/app/views/tmdb/actor_more.html.erb
+++ b/app/views/tmdb/actor_more.html.erb
@@ -1,32 +1,32 @@
 <article id="profile">
   <div class="row">
     <div class="summary-box">
-      <%= image_tag(TmdbImageService.image_url(file_path: @results.actor.profile.profile_path, size: :medium, image_type: :profile)) %>
+      <%= image_tag(TmdbImageService.image_url(file_path: @data.actor.profile.profile_path, size: :medium, image_type: :profile)) %>
       <div class="contents">
-        <h1><%= @results.actor.profile.name %></h1>
-        <h2>Born: <%= display_birthday_info(@results.actor.profile) %></h2>
-        <p class="bio"><%= @results.actor.profile.bio %></p>
+        <h1><%= @data.actor.profile.name %></h1>
+        <h2>Born: <%= display_birthday_info(@data.actor.profile) %></h2>
+        <p class="bio"><%= @data.actor.profile.bio %></p>
       </div> <!-- contents -->
     </div> <!-- summary-box -->
   </div> <!-- row -->
 
   <div class="row">
     <div class="credits">
-      <%= render partial: "movie_credits", locals: { person_profile: @results.actor.profile, movie_credits: @results.actor.movie_credits } %>
+      <%= render partial: "movie_credits", locals: { person_profile: @data.actor.profile, movie_credits: @data.actor.movie_credits } %>
 
-      <%= render partial: "seen_movie_credits", locals: { person_profile: @results.actor.profile, movie_credits: @results.actor.movie_credits, movies_seen: @results.movies_seen } %>
+      <%= render partial: "seen_movie_credits", locals: { person_profile: @data.actor.profile, movies_seen: @data.movies_seen } %>
 
-      <%= render partial: "tv_credits", locals: { tv_credits: @results.actor.tv_credits, actor_id: @results.actor.person_id }  %>
+      <%= render partial: "tv_credits", locals: { tv_credits: @data.actor.tv_credits, actor_id: @data.actor.person_id }  %>
 
-      <%= render partial: "director_credits", locals: { movie_credits: @results.actor.movie_credits, tv_credits: @results.actor.tv_credits }  %>
+      <%= render partial: "director_credits", locals: { movie_credits: @data.actor.movie_credits, tv_credits: @data.actor.tv_credits }  %>
 
-      <%= render partial: "producer_credits", locals: { movie_credits: @results.actor.movie_credits, tv_credits: @results.actor.tv_credits }  %>
+      <%= render partial: "producer_credits", locals: { movie_credits: @data.actor.movie_credits, tv_credits: @data.actor.tv_credits }  %>
 
-      <%= render partial: "editor_credits", locals: { movie_credits: @results.actor.movie_credits, tv_credits: @results.actor.tv_credits }  %>
+      <%= render partial: "editor_credits", locals: { movie_credits: @data.actor.movie_credits, tv_credits: @data.actor.tv_credits }  %>
 
-      <%= render partial: "writer_credits", locals: { movie_credits: @results.actor.movie_credits, tv_credits: @results.actor.tv_credits }  %>
+      <%= render partial: "writer_credits", locals: { movie_credits: @data.actor.movie_credits, tv_credits: @data.actor.tv_credits }  %>
 
-      <%= render partial: "screenplay_credits", locals: { movie_credits: @results.actor.movie_credits, tv_credits: @results.actor.tv_credits }  %>
+      <%= render partial: "screenplay_credits", locals: { movie_credits: @data.actor.movie_credits, tv_credits: @data.actor.tv_credits }  %>
     </div>
   </div>
 </article>


### PR DESCRIPTION
## Problems Solved
Sometimes I don't know how I know someone's face. I know I've seen them in movies, but I don't remember which. This exploratory PR adds a "movies seen" section to an actor's bio page. It does not address TV actors.

## Screenshots
Sandy B has been in 60 movies. These are the movies I've seen her in. 
<img width="599" alt="Screen Shot 2022-06-14 at 7 28 23 PM" src="https://user-images.githubusercontent.com/8680712/173711408-bdd0790d-adb3-4817-94fa-10a0c4836542.png">
<img width="581" alt="Screen Shot 2022-06-14 at 7 28 32 PM" src="https://user-images.githubusercontent.com/8680712/173711414-1ac86f51-ff16-4a65-a4e4-306bc0be6d40.png">


## Things Learned
* It can be hard to figure out a clever solution for this kind of UX problem.
* Sometimes it is good to just :yolo: and see if the users (us) like the implementation.
