### PR TITLE
WIP Link to actor bio from modal

### DIFF
--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -77,7 +77,12 @@ class TmdbController < ApplicationController
   end
 
   def actor_more
-    actor_data = PersonDataService.get_person_profile_data(params[:actor_id])
+    actor_id = if params[:actor_name].present?
+      PersonDataService.get_person_id(params[:actor_name])
+    else
+      params[:actor_id]
+    end
+    actor_data = PersonDataService.get_person_profile_data(actor_id)
     movies_seen = current_user.watched_movies.pluck(:tmdb_id)
     actor_movies_seen = actor_data.movie_credits.actor.select { |m| movies_seen.include?(m.tmdb_id) }
 

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -74,8 +74,9 @@ module MoviesHelper
   private
 
   def movie_actors_display(movie, qty)
-    raw(movie.actors.first(qty).map do |actor|
-      link_to actor, actor_search_path(actor: I18n.transliterate(actor)), class: 'cast-name-link'
+    raw(movie.actors.first(qty).map do |actor_name|
+      # link_to actor_name, actor_search_path(actor: I18n.transliterate(actor_name)), class: 'cast-name-link'
+      link_to actor_name, actor_more_path(actor_id: nil, actor_name: actor_name), class: 'cast-name-link'
     end.join(""))
   end
 

--- a/app/services/person_data_service.rb
+++ b/app/services/person_data_service.rb
@@ -6,6 +6,11 @@ module PersonDataService
     data.select { |result| result[:media_type] == 'person' }&.map { |result| result[:name] }&.uniq
   end
 
+  def self.get_person_id(query)
+    data = Tmdb::Client.request(:multi_search, query: query)[:results]
+    data.select { |result| result[:media_type] == 'person' }&.first&.dig(:id)
+  end
+
   def self.get_person_profile_data(person_id)
     person_data = Tmdb::Client.request(:person_data, person_id: person_id)
     movie_credits_data = Tmdb::Client.request(:person_movie_credits, person_id: person_id)


### PR DESCRIPTION
## Related Issues & PRs
Closes #333

## Problems Solved
Currently, when you click an actor's name on the movie show page or the modal,
<img width="538" alt="Screen Shot 2022-12-19 at 6 46 21 PM" src="https://user-images.githubusercontent.com/8680712/208555594-f5a3dabe-0a82-48fb-95e3-284c737dd044.png">

you're going to a movies search page where you see a button to go to the bio and a bunch of movies the actor has been in.
<img width="724" alt="Screen Shot 2022-12-19 at 6 48 01 PM" src="https://user-images.githubusercontent.com/8680712/208555701-f21fa323-76b8-4b68-9bc8-7b03895e55a3.png">

We have found that we want to skip this step and go straight to the actor's bio page.
<img width="978" alt="Screen Shot 2022-12-19 at 6 49 03 PM" src="https://user-images.githubusercontent.com/8680712/208555788-df5e4c10-6f83-4279-afcd-588122ca0908.png">

This PR does the work of linking directly to the actor's bio page.

## Things Learned
*
