### PR TITLE
Remove instance variables from api  data-parsing poros

### DIFF
--- a/app/models/movie_cast.rb
+++ b/app/models/movie_cast.rb
@@ -1,6 +1,9 @@
-class MovieCast
-  def initialize(actor_id, credit_id, name, character_name, profile_path, cast_id, order )
+# frozen_string_literal: true
 
+class MovieCast
+  attr_accessor :title, :actor_id, :credit_id, :name, :character_name, :profile_path, :cast_id, :order
+
+  def initialize(actor_id:, credit_id:, name:, character_name:, profile_path:, cast_id:, order:)
     @actor_id = actor_id
     @credit_id = credit_id
     @name = name
@@ -8,29 +11,19 @@ class MovieCast
     @profile_path = profile_path
     @cast_id = cast_id
     @order = order
+  end
 
-  end #init
-
-  attr_accessor :title, :actor_id, :credit_id, :name, :character_name, :profile_path, :cast_id, :order
-
-
-  def self.parse_results(json)
-    @actors = []
-    json.each do |result|
-      @actor_id = result[:id]
-      @credit_id = result[:credit_id]
-      @name = result[:name]
-      @character_name = result[:character]
-      @profile_path = result[:profile_path]
-      @order = result[:order]
-      @cast_id = result[:cast_id]
-
-      @actor = MovieCast.new(@actor_id, @credit_id, @name, @character_name, @profile_path, @order, @cast_id)
-      @actors << @actor
-    end #results loop
-    @actors
-  end #parse results
-
-end #class MovieCast
-
-
+  def self.parse_results(results)
+    results.map do |result|
+      new(
+        actor_id: result[:id],
+        credit_id: result[:credit_id],
+        name: result[:name],
+        character_name: result[:character],
+        profile_path: result[:profile_path],
+        order: result[:order],
+        cast_id: result[:cast_id]
+      )
+    end
+  end
+end

--- a/app/models/movie_credits.rb
+++ b/app/models/movie_credits.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 class MovieCredits
+  attr_accessor :adult, :credit_id, :department, :job, :tmdb_id, :title, :poster_path, :date, :character
 
-  def initialize(adult, credit_id, department, job, tmdb_id, title, poster_path, date, character)
-
+  def initialize(adult:, credit_id:, department:, job:, tmdb_id:, title:, poster_path:, date:, character:)
     @adult = adult
     @credit_id = credit_id
     @department = department
@@ -11,32 +13,29 @@ class MovieCredits
     @poster_path = poster_path
     @date = date
     @character = character
+  end
 
-  end #init
+  class << self
+    def parse(results)
+      results.map do |result|
+        new(
+          adult: result[:adult],
+          credit_id: result[:credit_id],
+          department: result[:department],
+          job: result[:job],
+          tmdb_id: result[:id],
+          title: result[:title],
+          poster_path: result[:poster_path],
+          date: format_release_date(result[:release_date]),
+          character: result[:character]
+        )
+      end.sort_by { |credit| credit.date }.reverse
+    end
 
-  attr_accessor :adult, :credit_id, :department, :job, :tmdb_id, :title, :poster_path, :date, :character
+    private
 
-  def self.parse(json)
-    @credits = []
-    json.each do |result|
-      @adult = result[:adult]
-      @credit_id = result[:credit_id]
-      @department = result[:department]
-      @job = result[:job]
-      @tmdb_id = result[:id]
-      @title = result[:title]
-      @poster_path = result[:poster_path]
-      if result[:release_date].present?
-        @date = Date.parse(result[:release_date]).stamp("2001")
-      else
-        @date = "Date unavailable"
-      end
-      @character = result[:character] if result[:character].present?
-
-      @credit = MovieCredits.new(@adult, @credit_id, @department, @job, @tmdb_id, @title, @poster_path, @date, @character)
-      @credits << @credit
-    end #loop
-    @credits = @credits.sort_by{ |credit| credit.date }.reverse
-  end #parse
-
-end #class
+    def format_release_date(date_data)
+      date_data.present? ? Date.parse(date_data).stamp('2001') : 'Date unavailable'
+    end
+  end
+end

--- a/app/models/movie_directing.rb
+++ b/app/models/movie_directing.rb
@@ -1,31 +1,27 @@
-class MovieDirecting
-  def initialize(director_id, credit_id, name, department, profile_path, job )
+# frozen_string_literal: true
 
+class MovieDirecting
+  attr_accessor :director_id, :credit_id, :name, :department, :profile_path, :job
+
+  def initialize(director_id:, credit_id:, name:, department:, profile_path:, job:)
     @director_id = director_id
     @credit_id = credit_id
     @name = name
     @profile_path = profile_path
     @department = department
     @job = job
+  end
 
-  end #init
-
-  attr_accessor :director_id, :credit_id, :name, :department, :profile_path, :job
-
-  def self.parse_results(json)
-    @directors = []
-    json.each do |result|
-      @director_id = result[:id]
-      @credit_id = result[:credit_id]
-      @name = result[:name]
-      @profile_path = result[:profile_path]
-      @job = result[:job]
-      @department = result[:department]
-
-      @director = MovieDirecting.new(@director_id, @credit_id, @name, @department, @profile_path, @job)
-      @directors << @director
-    end #results loop
-    @directors
-  end #parse results
-
-end #class
+  def self.parse_results(results)
+    results.map do |result|
+      new(
+        director_id: result[:id],
+        credit_id: result[:credit_id],
+        name: result[:name],
+        profile_path: result[:profile_path],
+        department: result[:department],
+        job: result[:job],
+      )
+    end
+  end
+end

--- a/app/models/movie_editing.rb
+++ b/app/models/movie_editing.rb
@@ -1,31 +1,27 @@
-class MovieEditing
-  def initialize(editor_id, credit_id, name, department, profile_path, job )
+# frozen_string_literal: true
 
+class MovieEditing
+  attr_accessor :editor_id, :credit_id, :name, :department, :profile_path, :job
+
+  def initialize(editor_id:, credit_id:, name:, department:, profile_path:, job:)
     @editor_id = editor_id
     @credit_id = credit_id
     @name = name
     @profile_path = profile_path
     @department = department
     @job = job
+  end
 
-  end #init
-
-  attr_accessor :editor_id, :credit_id, :name, :department, :profile_path, :job
-
-  def self.parse_results(json)
-    @editors = []
-    json.each do |result|
-      @editor_id = result[:id]
-      @credit_id = result[:credit_id]
-      @name = result[:name]
-      @profile_path = result[:profile_path]
-      @job = result[:job]
-      @department = result[:department]
-
-      @editor = MovieEditing.new(@editor_id, @credit_id, @name, @department, @profile_path, @job)
-      @editors << @editor
-    end #results loop
-    @editors
-  end #parse results
-
+  def self.parse_results(results)
+    results.map do |result|
+      new(
+        editor_id: result[:id],
+        credit_id: result[:credit_id],
+        name: result[:name],
+        department: result[:department],
+        profile_path: result[:profile_path],
+        job: result[:job]
+      )
+    end
+  end
 end

--- a/app/models/movie_person_credits.rb
+++ b/app/models/movie_person_credits.rb
@@ -1,30 +1,25 @@
+# frozen_string_literal: true
+
 class MoviePersonCredits
+  attr_accessor :directing, :editing, :writing, :screenplay, :producer, :actor
 
-  def initialize(movies, tv, directing, editing, writing, screenplay, producer, actor)
-
-    @movies = movies
-    @tv = tv
+  def initialize(directing:, editing:, writing:, screenplay:, producer:, actor:)
     @directing = directing
     @editing = editing
     @writing = writing
     @screenplay = screenplay
     @producer = producer
     @actor = actor
-
-  end #init
-
-  attr_accessor :movies, :tv, :directing, :editing, :writing, :screenplay, :producer, :actor
+  end
 
   def self.parse_result(result)
-    @actor = MovieCredits.parse(result[:cast])
-    @directing = MovieCredits.parse(result[:crew].select { |crew| crew[:job] == "Director" })
-    @editing = MovieCredits.parse(result[:crew].select { |crew| crew[:job] == "Editor" })
-    @writing = MovieCredits.parse(result[:crew ].select { |crew| crew[:job] == "Writer" })
-    @screenplay = MovieCredits.parse(result[:crew].select { |crew| crew[:job] == "Screenplay" })
-    @producer = MovieCredits.parse(result[:crew].select { |crew| crew[:job].include?("Producer") })
-
-    MoviePersonCredits.new(@movies, @tv, @directing, @editing, @writing, @screenplay, @producer, @actor)
-
-  end #parse result
-
-end #class
+    new(
+      directing: MovieCredits.parse(result[:crew].select { |crew| crew[:job] == 'Director' }),
+      editing: MovieCredits.parse(result[:crew].select { |crew| crew[:job] == 'Editor' }),
+      writing: MovieCredits.parse(result[:crew ].select { |crew| crew[:job] == 'Writer' }),
+      screenplay: MovieCredits.parse(result[:crew].select { |crew| crew[:job] == 'Screenplay' }),
+      producer: MovieCredits.parse(result[:crew].select { |crew| crew[:job].include?('Producer') }),
+      actor: MovieCredits.parse(result[:cast])
+    )
+  end
+end

--- a/app/models/movie_person_profile.rb
+++ b/app/models/movie_person_profile.rb
@@ -1,4 +1,8 @@
+# frozen_string_literal: true
+
 class MoviePersonProfile
+  attr_accessor :person_id, :name, :bio, :birthday, :deathday, :profile_path
+
   def initialize(args)
     @person_id = args[:person_id]
     @profile_path = args[:profile_path]
@@ -8,8 +12,6 @@ class MoviePersonProfile
     @deathday = args[:deathday]
   end
 
-  attr_accessor :person_id, :name, :bio, :birthday, :deathday, :profile_path
-
   WIKIPEDIA_CREDIT = {
     starting: 'From Wikipedia, the free encyclopedia.',
     trailing: 'Description above from Wikipedia.',
@@ -18,7 +20,7 @@ class MoviePersonProfile
 
   class << self
     def parse_result(result)
-      MoviePersonProfile.new(
+      new(
         person_id: result[:id],
         profile_path: result[:profile_path],
         name: result[:name],
@@ -27,6 +29,8 @@ class MoviePersonProfile
         deathday: parse_date(result[:deathday])
       )
     end
+
+    private
 
     def parse_bio(biography)
       return 'Bio not available.' if biography.blank?

--- a/app/models/movie_search.rb
+++ b/app/models/movie_search.rb
@@ -1,7 +1,7 @@
 class MovieSearch
   attr_accessor :title, :in_db, :tmdb_id, :release_date, :vote_average, :overview, :backdrop_path, :poster_path, :tags, :lists
 
-  def initialize(title:, in_db:, tmdb_id:, release_date:, vote_average:, overview:, backdrop_path:, poster_path:, tags:, lists:)
+  def initialize(title:, in_db:, tmdb_id:, release_date:, vote_average:, overview:, backdrop_path:, poster_path:)
     @title = title
     @in_db = in_db
     @tmdb_id = tmdb_id
@@ -10,8 +10,8 @@ class MovieSearch
     @overview = overview
     @backdrop_path = backdrop_path
     @poster_path = poster_path
-    @tags = tags
-    @lists = lists
+    @tags = nil
+    @lists = nil
   end
 
   def self.parse_results(results)
@@ -30,9 +30,7 @@ class MovieSearch
           vote_average: result[:vote_average]&.round(1),
           overview: result[:overview],
           backdrop_path: result[:backdrop_path],
-          poster_path: result[:poster_path],
-          tags: nil,
-          lists: nil
+          poster_path: result[:poster_path]
         )
       end
     end

--- a/app/models/movie_search.rb
+++ b/app/models/movie_search.rb
@@ -1,6 +1,7 @@
 class MovieSearch
-  def initialize(title, in_db, tmdb_id, release_date, vote_average, overview, backdrop_path, poster_path, tags, lists)
+  attr_accessor :title, :in_db, :tmdb_id, :release_date, :vote_average, :overview, :backdrop_path, :poster_path, :tags, :lists
 
+  def initialize(title:, in_db:, tmdb_id:, release_date:, vote_average:, overview:, backdrop_path:, poster_path:, tags:, lists:)
     @title = title
     @in_db = in_db
     @tmdb_id = tmdb_id
@@ -13,30 +14,27 @@ class MovieSearch
     @lists = lists
   end
 
-  attr_accessor :title, :in_db, :tmdb_id, :release_date, :vote_average, :overview, :backdrop_path, :poster_path, :tags, :lists
+  def self.parse_results(results)
+    results.map do |result|
+      tmdb_id = result[:id]
+      existing_movie = Movie.find_by(tmdb_id: @tmdb_id)
 
-  def self.parse_results(json)
-    @movies = []
-    json.each do |result|
-      @tmdb_id = result[:id]
-      @in_db = Movie.exists?(tmdb_id: @tmdb_id)
-        if @in_db
-          @movies << Movie.find_by(tmdb_id: @tmdb_id)
-        else
-          @title = result[:title]
-          @release_date = result[:release_date]
-          @vote_average = result[:vote_average]&.round(1)
-          @overview = result[:overview]
-          @backdrop_path = result[:backdrop_path]
-          @poster_path = result[:poster_path]
-          @tags = nil
-          @lists = nil
-
-          @movie = MovieSearch.new(@title, @in_db, @tmdb_id, @release_date, @vote_average, @overview, @backdrop_path, @poster_path, @tags, @lists)
-          @movies << @movie
-        end
-    end #loop
-    @movies
+      if existing_movie.present?
+        existing_movie
+      else
+        new(
+          title: result[:title],
+          in_db: false,
+          tmdb_id: tmdb_id,
+          release_date: result[:release_date],
+          vote_average: result[:vote_average]&.round(1),
+          overview: result[:overview],
+          backdrop_path: result[:backdrop_path],
+          poster_path: result[:poster_path],
+          tags: nil,
+          lists: nil
+        )
+      end
+    end
   end
-
 end

--- a/app/models/tv_actor_credit.rb
+++ b/app/models/tv_actor_credit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TVActorCredit
   attr_accessor :show_name, :show_id, :actor_name, :actor_id, :character, :seasons, :episodes, :profile_path, :known_for
 

--- a/app/models/tv_cast_member.rb
+++ b/app/models/tv_cast_member.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TVCastMember
   attr_accessor :actor_id, :credit_id, :name, :character_name, :profile_path, :order
 
@@ -21,8 +23,8 @@ class TVCastMember
     )
   end
 
-  def self.parse_records(json)
-    json.map do |record|
+  def self.parse_records(records)
+    records.map do |record|
       parse_record(record)
     end.sort_by { |r| r.order }
   end

--- a/app/models/tv_credit_season.rb
+++ b/app/models/tv_credit_season.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TVCreditSeason
   attr_accessor :air_date, :episode_count, :id, :name, :overview, :poster_path, :season_number, :show_id
 
@@ -12,14 +14,14 @@ class TVCreditSeason
     @show_id = show_id
   end
 
-  def self.parse_records(json)
-    json.map do |record|
+  def self.parse_records(records)
+    records.map do |record|
       parse_record(record)
     end.sort_by { |r| r.season_number }
   end
 
   def self.parse_record(record)
-    air_date = Date.parse(record[:air_date]).stamp("1/2/2001") if record[:air_date].present?
+    air_date = Date.parse(record[:air_date]).stamp('1/2/2001') if record[:air_date].present?
     new(
       air_date: air_date,
       episode_count: record[:episode_count],

--- a/app/models/tv_credits.rb
+++ b/app/models/tv_credits.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 class TVCredits
+  attr_accessor :credit_id, :department, :job, :show_id, :show_name, :poster_path, :character, :first_air_date
 
-  def initialize(credit_id, department, job, show_id, show_name, poster_path, character, first_air_date)
-
+  def initialize(credit_id:, department:, job:, show_id:, show_name:, poster_path:, character:, first_air_date:)
     @credit_id = credit_id
     @department = department
     @job = job
@@ -10,31 +12,28 @@ class TVCredits
     @poster_path = poster_path
     @character = character
     @first_air_date = first_air_date
+  end
 
-  end #init
+  class << self
+    def parse(results)
+      results.map do |result|
+        new(
+          credit_id: result[:credit_id],
+          department: result[:department],
+          job: result[:job],
+          show_id: result[:id],
+          show_name: result[:name],
+          poster_path: result[:poster_path],
+          character: result[:character],
+          first_air_date: format_first_air_date(result[:first_air_date])
+        )
+      end.sort_by { |credit| credit.first_air_date }.reverse
+    end
 
-  attr_accessor :credit_id, :department, :job, :show_id, :show_name, :poster_path, :character, :first_air_date
+    private
 
-  def self.parse(json)
-    @credits = []
-    json.each do |result|
-      @credit_id = result[:credit_id]
-      @department = result[:department]
-      @job = result[:job]
-      @show_id = result[:id]
-      @show_name = result[:name]
-      @poster_path = result[:poster_path]
-      @character = result[:character]
-      if result[:first_air_date].present?
-        @first_air_date = Date.parse(result[:first_air_date]).stamp("2001")
-      else
-        @first_air_date = "Date unavailable"
-      end
-
-      @credit = TVCredits.new(@credit_id, @department, @job, @show_id, @show_name, @poster_path, @character, @first_air_date)
-      @credits << @credit
-    end #loop
-    @credits = @credits.sort_by{ |credit| credit.first_air_date }.reverse
-  end #parse
-
-end #class
+    def format_first_air_date(date_data)
+      date_data.present? ? Date.parse(date_data).stamp('2001') : 'Date unavailable'
+    end
+  end
+end

--- a/app/models/tv_person_credits.rb
+++ b/app/models/tv_person_credits.rb
@@ -1,28 +1,23 @@
 class TVPersonCredits
+  attr_accessor :directing, :editing, :writing, :screenplay, :producer, :actor
 
-  def initialize(directing, editing, writing, screenplay, producer, actor)
-
+  def initialize(directing:, editing:, writing:, screenplay:, producer:, actor:)
     @directing = directing
     @editing = editing
     @writing = writing
     @screenplay = screenplay
     @producer = producer
     @actor = actor
-
-  end #init
-
-  attr_accessor :directing, :editing, :writing, :screenplay, :producer, :actor
+  end
 
   def self.parse_result(result)
-    @actor = TVCredits.parse(result[:cast])
-    @directing = TVCredits.parse(result[:crew].select { |crew| crew[:job] == "Director" })
-    @editing = TVCredits.parse(result[:crew].select { |crew| crew[:job] == "Editor" })
-    @writing = TVCredits.parse(result[:crew ].select { |crew| crew[:job] == "Writer" })
-    @screenplay = TVCredits.parse(result[:crew].select { |crew| crew[:job] == "Screenplay" })
-    @producer = TVCredits.parse(result[:crew].select { |crew| crew[:job].include?("Producer") })
-
-    TVPersonCredits.new(@directing, @editing, @writing, @screenplay, @producer, @actor)
-
-  end #parse result
-
-end #class
+    new(
+      directing: TVCredits.parse(result[:crew].select { |crew| crew[:job] == 'Director' }),
+      editing: TVCredits.parse(result[:crew].select { |crew| crew[:job] == 'Editor' }),
+      writing: TVCredits.parse(result[:crew ].select { |crew| crew[:job] == 'Writer' }),
+      screenplay: TVCredits.parse(result[:crew].select { |crew| crew[:job] == 'Screenplay' }),
+      producer: TVCredits.parse(result[:crew].select { |crew| crew[:job].include?('Producer') }),
+      actor: TVCredits.parse(result[:cast])
+    )
+  end
+end

--- a/app/models/tv_season.rb
+++ b/app/models/tv_season.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TVSeason
   attr_accessor :series, :show_id, :air_date, :name, :overview, :season_id, :poster_path, :season_number, :credits, :cast_members, :episodes
 

--- a/app/models/tv_series.rb
+++ b/app/models/tv_series.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TVSeries
   attr_accessor :show_id, :first_air_date, :last_air_date, :show_name, :backdrop_path, :poster_path, :number_of_episodes, :number_of_seasons, :overview, :seasons, :actors
 
@@ -17,8 +19,8 @@ class TVSeries
 
   def self.parse_search_records(results)
     results.map do|result|
-      first_air_date = Date.parse(result[:first_air_date])&.stamp("1/2/2001") if result[:first_air_date].present?
-      TVSeries.new(
+      first_air_date = Date.parse(result[:first_air_date])&.stamp('1/2/2001') if result[:first_air_date].present?
+      new(
         show_id: result[:id],
         first_air_date: first_air_date,
         last_air_date: nil,
@@ -35,12 +37,12 @@ class TVSeries
   end
 
   def self.parse_record(result, show_id)
-    first_air_date = Date.parse(result[:first_air_date]).stamp("1/2/2001") if result[:first_air_date].present?
-    last_air_date = Date.parse(result[:last_air_date]).stamp("1/2/2001") if result[:last_air_date].present?
+    first_air_date = Date.parse(result[:first_air_date]).stamp('1/2/2001') if result[:first_air_date].present?
+    last_air_date = Date.parse(result[:last_air_date]).stamp('1/2/2001') if result[:last_air_date].present?
     seasons = (1..(result[:number_of_seasons])).to_a if result[:number_of_seasons].present?
     actors = TVCastMember.parse_records(result[:credits][:cast])
 
-    @series = TVSeries.new(
+    new(
       show_id: show_id,
       first_air_date: first_air_date,
       last_air_date: last_air_date,

--- a/spec/models/movie_person_profile_spec.rb
+++ b/spec/models/movie_person_profile_spec.rb
@@ -92,16 +92,16 @@ RSpec.describe MoviePersonProfile, type: :model do
     end
   end
 
-  describe '.parse_bio' do
+  describe 'private.parse_bio' do
     it 'returns a biography if one is present' do
       bio = results_for_known_person[:biography]
 
-      expect(MoviePersonProfile.parse_bio(bio).present?).to be true
+      expect(MoviePersonProfile.send(:parse_bio, bio).present?).to be true
     end
 
     it 'returns a "not available" message if no bio is present' do
       bio = results_for_known_person_without_details[:biography]
-      parsed_bio = MoviePersonProfile.parse_bio(bio.clone)
+      parsed_bio = MoviePersonProfile.send(:parse_bio, bio.clone)
       message = 'not available'
 
       expect(parsed_bio.downcase.include?(message)).to be true
@@ -109,71 +109,72 @@ RSpec.describe MoviePersonProfile, type: :model do
 
     it 'replaces carriage returns with <br>' do
       bio = results_for_known_person[:biography]
-      parsed_bio = MoviePersonProfile.parse_bio(bio.clone)
+      parsed_bio = MoviePersonProfile.send(:parse_bio, bio.clone)
 
       expect(parsed_bio.downcase.include?('<br>')).to be true
       expect(parsed_bio.downcase.include?("\r\n")).to be false
     end
   end
 
-  describe '.standardize_wikipedia_credit' do
+  describe 'private.standardize_wikipedia_credit' do
     it 'removes starting Wikipedia credit if there is one' do
       bio = results_for_known_person[:biography]
-      stripped_bio = MoviePersonProfile.standardize_wikipedia_credit(bio.clone)
+      stripped_bio = MoviePersonProfile.send(:standardize_wikipedia_credit, bio.clone)
 
       expect(stripped_bio.include?(MoviePersonProfile::WIKIPEDIA_CREDIT[:starting])).to be false
     end
 
     it 'removes trailing Wikipedia credit if there is one' do
       bio = results_for_known_person[:biography]
-      stripped_bio = MoviePersonProfile.standardize_wikipedia_credit(bio.clone)
+      stripped_bio = MoviePersonProfile.send(:standardize_wikipedia_credit, bio.clone)
 
       expect(stripped_bio.include?(MoviePersonProfile::WIKIPEDIA_CREDIT[:trailing])).to be false
     end
 
     it 'appends "Bio from Wikipedia" if there were any Wikipedia credits' do
       bio = results_for_known_person[:biography]
-      stripped_bio = MoviePersonProfile.standardize_wikipedia_credit(bio.clone)
+      stripped_bio = MoviePersonProfile.send(:standardize_wikipedia_credit, bio.clone)
 
       expect(stripped_bio.include?(MoviePersonProfile::WIKIPEDIA_CREDIT[:standard])).to be true
     end
 
     it 'appends nothing if there were not any Wikipedia credits' do
       bio = results_for_unknown_person[:biography]
-      stripped_bio = MoviePersonProfile.standardize_wikipedia_credit(bio.clone)
+      stripped_bio = MoviePersonProfile.send(:standardize_wikipedia_credit, bio.clone)
 
       expect(stripped_bio.include?(MoviePersonProfile::WIKIPEDIA_CREDIT[:standard])).to be false
     end
   end
 
-  describe '.wikipedia_credit?' do
+  describe 'private.wikipedia_credit?' do
     it 'returns true if a starting Wikipedia credit exists' do
       bio = "#{MoviePersonProfile::WIKIPEDIA_CREDIT[:starting]} Bio Goes here."
-      expect(MoviePersonProfile.wikipedia_credit?(bio)).to be true
+
+      expect(MoviePersonProfile.send(:wikipedia_credit?, bio)).to be true
     end
 
     it 'returns true if a trailing Wikipedia credit exists' do
       bio = "Bio Goes here. #{MoviePersonProfile::WIKIPEDIA_CREDIT[:trailing]}"
-      expect(MoviePersonProfile.wikipedia_credit?(bio)).to be true
+      expect(MoviePersonProfile.send(:wikipedia_credit?, bio)).to be true
     end
 
     it 'returns false if there is no credit for Wikipedia' do
       bio = 'Bio Goes here.'
-      expect(MoviePersonProfile.wikipedia_credit?(bio)).to be false
+      expect(MoviePersonProfile.send(:wikipedia_credit?, bio)).to be false
     end
   end
 
-  describe '.parse_date' do
+  describe 'private.parse_date' do
     it 'returns an empty string if there is no date provided' do
       birthday = nil
-      parsed_birthday = MoviePersonProfile.parse_date(birthday)
+      parsed_birthday = MoviePersonProfile.send(:parse_date, birthday)
 
       expect(parsed_birthday).to eq('')
     end
 
     it 'returns the date in string format if there is a date provided' do
       birthday = '2018-01-31'
-      parsed_birthday = MoviePersonProfile.parse_date(birthday)
+      parsed_birthday = MoviePersonProfile.send(:parse_date, birthday)
 
       expect(parsed_birthday).to eq(birthday)
     end


### PR DESCRIPTION
## Problems Solved
About a year ago I did a big push to refactor the `tmdb_controller` and related service objects with the goal of getting rid of rogue instance variables (as outlined in #270). I did _most_ of the work, but stopped just short of doing _all_ of the work. This PR cleans up the last of those API data-parsing POROs that had unnecessary instance variables in them.

This PR also cleans up a lot of spacing, unnecessary comments (like where a block ends), placement conventions, and changes `"` to `'` for easier rubocopping.

## Things Learned
* When we first built this app, naming was hard and staying organized was also hard. We're dealing with some of that weirdness today.
* All of the work we did last December really encapsulated those POROs, so when I went back for this refactor today, the tests were all green!

## Moving Forward
* I'd like to move our non-AR-backed models into another directory. [Bob Martin suggests](http://blog.vladimir-rybas.com/blog/2014/04/04/rails-and-pipes/)  using `entities` for nouns and `use_cases` for verbs.
