### PR TITLE
Make MovieSearch object consistently return MovieSearch object 

### DIFF
--- a/app/entities/movie_search_result.rb
+++ b/app/entities/movie_search_result.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MovieSearch
+class MovieSearchResult
   attr_accessor :title, :in_db, :tmdb_id, :release_date, :vote_average, :overview, :backdrop_path, :poster_path, :tags, :lists
 
   def initialize(title:, in_db:, tmdb_id:, release_date:, vote_average:, overview:, backdrop_path:, poster_path:)
@@ -16,25 +16,18 @@ class MovieSearch
     @lists = nil
   end
 
-  def self.parse_results(results)
+  def self.build_list(results)
     results.map do |result|
-      tmdb_id = result[:id]
-      existing_movie = Movie.find_by(tmdb_id: @tmdb_id)
-
-      if existing_movie.present?
-        existing_movie
-      else
-        new(
-          title: result[:title],
-          in_db: false,
-          tmdb_id: tmdb_id,
-          release_date: result[:release_date],
-          vote_average: result[:vote_average]&.round(1),
-          overview: result[:overview],
-          backdrop_path: result[:backdrop_path],
-          poster_path: result[:poster_path]
-        )
-      end
+      new(
+        title: result[:title],
+        in_db: false,
+        tmdb_id: tmdb_id = result[:id],
+        release_date: result[:release_date],
+        vote_average: result[:vote_average]&.round(1),
+        overview: result[:overview],
+        backdrop_path: result[:backdrop_path],
+        poster_path: result[:poster_path]
+      )
     end
   end
 end

--- a/app/services/movie_data_service.rb
+++ b/app/services/movie_data_service.rb
@@ -14,6 +14,7 @@ module MovieDataService
   ["unwatched movies", "unwatched movies"], ["only show unwatched", "only show unwatched"],
   ["only show watched", "only show watched"], ["movies not on a list", "movies not on a list"] ]
 
+  # TODO: move these into a TMDB::MenuOptions module
   GENRES = [["Action", 28], ["Adventure", 12], ["Animation", 16], ["Comedy", 35], ["Crime", 80],
   ["Documentary", 99], ["Drama", 18], ["Family", 10751], ["Fantasy", 14], ["Foreign", 10769], ["History", 36],
   ["Horror", 27], ["Music", 10402], ["Mystery", 9648], ["Romance", 10749], ["Science Fiction", 878], ["TV Movie", 10770],
@@ -76,7 +77,7 @@ module MovieDataService
     def get_movie_title_search_results(movie_title)
       data = Tmdb::Client.request(:movie_search, query: movie_title)[:results]
       not_found = "No results for '#{movie_title}'." if data.blank?
-      movies = MovieSearch.parse_results(data) if data.present?
+      movies = MovieSearchResult.build_list(data) if data.present?
 
       OpenStruct.new(
         movie_title: movie_title,
@@ -100,7 +101,7 @@ module MovieDataService
       movie_results = data.dig(:results)
       return OpenStruct.new(not_found_message: "No results for #{searched_terms}.") if movie_results.blank?
 
-      movies = MovieSearch.parse_results(movie_results)
+      movies = MovieSearchResult.build_list(movie_results)
       total_pages = data.fetch(:total_pages)
       current_page = data[:page]
 
@@ -150,7 +151,7 @@ module MovieDataService
         id: person_data[:id],
         actor: person_data,
         actor_name: person_data[:name],
-        movies: MovieSearch.parse_results(movie_results),
+        movies: MovieSearchResult.build_list(movie_results),
         not_found_message: not_found_message,
         current_page: current_page,
         previous_page: (current_page - 1 if current_page > 1),
@@ -241,7 +242,7 @@ module MovieDataService
       OpenStruct.new(
         actor_names: actor_names,
         paginate_actor_names: actor_names.join(';'),
-        common_movies: MovieSearch.parse_results(movie_response[:results]),
+        common_movies: MovieSearchResult.build_list(movie_response[:results]),
         not_found_message: nil,
         current_page: current_page,
         previous_page: (current_page - 1 if current_page > 1),

--- a/app/views/movies/_movie_partial_loop.html.erb
+++ b/app/views/movies/_movie_partial_loop.html.erb
@@ -1,7 +1,7 @@
 <div class="row tile-container">
   <% movies.each do |movie| %>
     <article class="tile-cover-pic">
-      <!-- MODAL TRIGGERS -->
+      <!-- MODAL TRIGGER 1 of 2 -->
       <!-- On Desktop: Always display the modal -->
       <p id="modal-trigger">
         <%= link_to image_for(movie), movie_modal_path(tmdb_id: movie.tmdb_id, list_id: @list&.id),
@@ -11,7 +11,7 @@
                                       class: 'modal-linker'
         %>
       </p>
-
+      <!-- MODAL TRIGGER 2 of 2 -->
       <!-- On Mobile: skip the modal and go straight to a show page -->
       <p id="modal-trigger-mobile">
         <%= link_to image_for(movie), movie_more_path(tmdb_id: movie.tmdb_id) %>

--- a/app/views/movies/_movie_partial_loop.html.erb
+++ b/app/views/movies/_movie_partial_loop.html.erb
@@ -1,9 +1,9 @@
 <div class="row tile-container">
   <% movies.each do |movie| %>
     <article class="tile-cover-pic">
-      <!-- MODAL TRIGGER -->
+      <!-- MODAL TRIGGERS -->
+      <!-- On Desktop: Always display the modal -->
       <p id="modal-trigger">
-        <!-- Always display the modal on desktop -->
         <%= link_to image_for(movie), movie_modal_path(tmdb_id: movie.tmdb_id, list_id: @list&.id),
                                       remote: true,
                                       data: { target: "#myModal_#{movie.tmdb_id}" },
@@ -12,13 +12,9 @@
         %>
       </p>
 
+      <!-- On Mobile: skip the modal and go straight to a show page -->
       <p id="modal-trigger-mobile">
-        <!-- Get to a show page on mobile regardless of movie object persistence -->
-        <% if movie.is_a?(Movie) %>
-          <%= link_to image_for(movie), movie_path(movie) %>
-        <% else %>
-          <%= link_to image_for(movie), movie_more_path(tmdb_id: movie.tmdb_id) %>
-        <% end %>
+        <%= link_to image_for(movie), movie_more_path(tmdb_id: movie.tmdb_id) %>
       </p>
 
       <div id="movies_partial_<%= "#{movie.tmdb_id}" %>"></div>

--- a/spec/services/movie_data_service_spec.rb
+++ b/spec/services/movie_data_service_spec.rb
@@ -330,7 +330,7 @@ RSpec.describe MovieDataService do
         expect(results.not_found_message).to eq(nil)
       end
 
-      it 'returns a MovieSearch object with movie data' do
+      it 'returns a MovieSearchResult object with movie data' do
         results = described_class.get_common_movies_between_multiple_actors(actor_names: [actor1_name, actor2_name])
         expect(results.common_movies.length).to eq(common_movies_results[:results].length)
         expect(results.common_movies.first.title).to eq(movie_title)


### PR DESCRIPTION
## Problem Solved
In the `MovieSearch` class, we were returning a list of movie-like objects, some of which were instances of `MovieSearch` and others were instances of `Movie` depending on whether the movie data had been persisted to the database. Because this list could container either class, we had a condition in the view that switched routes depending on the class type.

## Summary of Changes Made
In this PR, the `MovieSearch` (now called `MovieSearchResult`) class method returns only instances of `MovieSearchResult`.  As it turns out, we were already doing a persistence check in the controller via our `GuaranteedMovie` object, so we don't have to concern ourselves with doing it again. So now, instead of doing the persistence check up front in the `MovieSearch` parsing method and then asking about it later in the view, we now only do it in the controller.

I've renamed these object for clarity:
```ruby
# before
MovieSearch.parse_results(api_data)

#after
MovieSearchResult.build_list(api_data)
```
