### PR TITLE
Configure new Sentry gems to only run in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,8 @@ gem 'will_paginate'
 gem 'coveralls', '0.8.11', require: false
 gem 'rack-mini-profiler'
 gem 'stamp'
-gem 'sentry-raven'
+gem 'sentry-ruby'
+gem 'sentry-rails'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,10 +103,6 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (2.6.0)
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
     ffaker (2.21.0)
     ffi (1.15.5)
     figaro (1.2.0)
@@ -171,6 +167,8 @@ GEM
     nenv (0.3.0)
     nio4r (2.5.8)
     nokogiri (1.13.9-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.9-x86_64-linux)
       racc (~> 1.4)
@@ -280,7 +278,6 @@ GEM
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.11.0)
-    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -300,8 +297,11 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
+    sentry-rails (5.7.0)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.7.0)
+    sentry-ruby (5.7.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     shellany (0.0.1)
     shoulda-matchers (5.2.0)
       activesupport (>= 5.2.0)
@@ -351,6 +351,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -386,7 +387,8 @@ DEPENDENCIES
   rubocop-rspec
   sass-rails
   sdoc (~> 0.4.0)
-  sentry-raven
+  sentry-rails
+  sentry-ruby
   shoulda-matchers
   stamp
   terminal-notifier-guard

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery prepend: true, with: :exception
-
+  before_action :set_sentry_context
   before_action :configure_permitted_parameters, if: :devise_controller?
 
 
@@ -17,5 +17,12 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :email, :password, :password_confirmation, :remember_me])
     devise_parameter_sanitizer.permit(:sign_in, keys: [:login, :username, :email, :password, :remember_me])
     devise_parameter_sanitizer.permit(:account_update, keys: [:username, :email, :default_location, :password, :password_confirmation, :current_password])
+  end
+
+  private
+
+  def set_sentry_context
+    counter = (Sentry.get_current_scope.tags[:counter] || 0) + 1
+    Sentry.set_tags(counter: counter)
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,8 +1,5 @@
-if Rails.env == 'production'
-  Raven.configure do |config|
-    config.dsn = ENV["SENTRY_DSN"]
-    config.environments = ['production']
-    config.should_capture = Proc.new { |e| Rails.env == 'production' }# unless e.contains_sensitive_info? }
-    config.tags = { environment: Rails.env }
-  end
+Sentry.init do |config|
+  config.dsn = ENV['SENTRY_DSN']
+  config.enabled_environments = %w[production]
+  config.breadcrumbs_logger = [:active_support_logger]
 end


### PR DESCRIPTION
## Problems Solved
Our Sentry gem was out of date and/or misconfigured so that in addition to production errors, we were sending development and test errors to Sentry. This PR switches us to the latest sentry gems and configures for only sending production errors to Sentry.

## To Do
- [x] confirm that it has stopped reporting for development
- [x] confirm that it is still reporting for production

## Related Docs
* https://github.com/getsentry/sentry-ruby
* https://docs.sentry.io/platforms/ruby/migration/
* https://docs.sentry.io/platforms/ruby/guides/rails/migration/

## Things Learned
* it sure is fun to test live in production. 😆 
