### PR TITLE
Add delay to search autocomplete 

### DIFF
--- a/app/assets/javascripts/z.js
+++ b/app/assets/javascripts/z.js
@@ -1,4 +1,6 @@
-$(document).ready(function(){
+var delayTime = 550; // ex: 600ms = 0.6sec
+
+$(document).ready(function () {
   $('.autocomplete-auto-submit').each(function(){
     var form = $(this)
     var source = form.data('autocomplete-source')
@@ -6,6 +8,7 @@ $(document).ready(function(){
     form.autocomplete({
       source: source,
       minLength: 4,
+      delay: delayTime,
       select: function (event, ui) {
         $(this).closest(".autocomplete-auto-submit").val(ui.item.value);
         $(this).closest("form").submit();
@@ -16,6 +19,7 @@ $(document).ready(function(){
 
   $( ".autocomplete-search-field" ).autocomplete({
     minLength: 4,
+    delay: delayTime,
     source: $(".autocomplete-search-field").data("autocomplete-source")
   });
 

--- a/app/assets/javascripts/z.js
+++ b/app/assets/javascripts/z.js
@@ -1,4 +1,4 @@
-var delayTime = 550; // ex: 600ms = 0.6sec
+var delayTime = 500; // ex: 500ms = 0.5sec
 
 $(document).ready(function () {
   $('.autocomplete-auto-submit').each(function(){


### PR DESCRIPTION
## Related Issues & PRs
Relates to #307

## Problems Solved
While we do have amazing responsiveness in our autocomplete fields, we're feeling a little jerkish for hammering on the free TMDB API. This PR adds a delay to the call to the API that happens during autocomplete -- in effect, reducing the calls to the API by about half without too much of a wait on the user's part.

## Screenshots
Before
![before2](https://user-images.githubusercontent.com/8680712/211101813-624a4d12-4e30-4d83-80d6-49aa50108d7b.gif)

After
![after](https://user-images.githubusercontent.com/8680712/211101544-01beea49-bbce-4181-85d7-40a953fd9e42.gif)

