### PR TITLE
346 display watched date in modal

### DIFF
--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -34,12 +34,12 @@ module MoviesHelper
   end
 
   def trailer_placeholder_text(movie)
-    change_or_add = movie.trailer.present? ? 'change the' : 'add a'
-    "To #{change_or_add} trailer, enter the YouTube URL"
+    change_or_add = movie.trailer.present? ? 'Change' : 'Add'
+    "Enter YouTube URL to #{change_or_add} Trailer"
   end
 
   def trailer_button_text(movie)
-    movie.trailer.present? ? 'Change trailer' : 'Add a trailer'
+    movie.trailer.present? ? 'Change' : '+ Add'
   end
 
   def movie_stats_display(movie)

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -68,6 +68,24 @@ module MoviesHelper
     end
   end
 
+  def firstify_number(number)
+    if number.to_s[-2..-1] == '11'
+      "#{number}th"
+    elsif number.to_s[-1] == '1'
+      "#{number}st"
+    elsif number.to_s[-2..-1] == '12'
+      "#{number}th"
+    elsif number.to_s[-1] == '2'
+      "#{number}nd"
+    elsif number.to_s[-2..-1] == '13'
+      "#{number}th"
+    elsif number.to_s[-1] == '3'
+      "#{number}rd"
+    else
+    "#{number}th"
+    end
+  end
+
   def movie_cast_display(movie, qty)
     cast = movie_actors_display(movie, qty)
     cast += movie_director_display(movie)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,8 @@
     <title><%= raw page_title %></title>
     <link href='https://fonts.googleapis.com/css?family=Nixie+One|Open+Sans:400,600,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.2/css/bootstrap.min.css">
-    <!-- Material Symbols, but not Mateiral Icons -->
+    <!-- Material Icons and Material Symbols are different. This stylesheet only accesses Material Symbols.
+    To use Material Symbols, it will require a little more set up. -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" />
 
     <%= stylesheet_link_tag    'application', media: 'all'%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <title><%= raw page_title %></title>
     <link href='https://fonts.googleapis.com/css?family=Nixie+One|Open+Sans:400,600,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.2/css/bootstrap.min.css">
+    <!-- Material Symbols, but not Mateiral Icons -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" />
 
     <%= stylesheet_link_tag    'application', media: 'all'%>

--- a/app/views/movies/_movie_modal_innard.html.erb
+++ b/app/views/movies/_movie_modal_innard.html.erb
@@ -6,7 +6,6 @@
         </div><!-- partial-spacer -->
 
         <% if movie.in_db && movie.lists.by_user(current_user).present? %>
-
         <div class="partial-spacer ui-front">
           <!-- ui-front is needed for jquery autocomplete in the modal -->
           <div id="movie_on_lists_<%= "#{movie.tmdb_id}" %>">
@@ -19,30 +18,33 @@
         </div><!-- partial-spacer -->
 
         <% if @list.present? && current_user.all_lists.include?(@list) %>
-
           <div class="partial-spacer">
             <div id="list_priority_<%= "#{movie.tmdb_id}" %>">
               <%= render 'movies/movie_list_priority', movie: movie %>
             </div>
-          </div> <!-- partial-spacer -->
+    </div>
           <% end %> <!-- #if @list.present? && current_user.all_lists.include?(@list)  -->
 
-        <% else %><!-- movie.in_db && movie.lists.by_user -->
-
+<% else %><!-- !movie.in_db or no user lists for movie -->
         <div class="partial-spacer ui-front">
           <!-- ui-front is needed for jquery autocomplete in the modal -->
           <div id="movie_add_to_first_list_<%= "#{movie.tmdb_id}" %>">
             <%= render 'movies/movie_add_to_first_list', movie: movie %>
           </div>
-        </div> <!-- partial-spacer -->
-
+  </div>
         <% end %><!-- movie.in_db && movie.lists.by_user -->
+
+<div class="partial-spacer">
+  <div id="movie_show_seen_<%= "#{movie.tmdb_id}" %>" class="partial-spacer">
+    <%= render "movies/movie_show_screening", movie: movie %>
+  </div>
+</div>
 
         <div class="partial-spacer">
           <div id="movie_rated_<%= "#{movie.tmdb_id}" %>">
             <%= render 'movies/movie_rating', movie: movie %>
           </div>
-        </div> <!-- partial-spacer -->
+</div>
 
         <div class="partial-spacer">
            <div id="movie_reviewed_<%= "#{movie.tmdb_id}" %>">

--- a/app/views/movies/_movie_modal_innard.html.erb
+++ b/app/views/movies/_movie_modal_innard.html.erb
@@ -1,38 +1,38 @@
 <hr>
-        <div class="partial-spacer">
-          <div id="movie_tagged_<%= "#{movie.tmdb_id}" %>">
-            <%= render 'movies/movie_tag', movie: movie %>
-          </div>
-        </div><!-- partial-spacer -->
+<div class="partial-spacer">
+  <div id="movie_tagged_<%= "#{movie.tmdb_id}" %>">
+    <%= render 'movies/movie_tag', movie: movie %>
+  </div>
+</div><!-- partial-spacer -->
 
-        <% if movie.in_db && movie.lists.by_user(current_user).present? %>
-        <div class="partial-spacer ui-front">
-          <!-- ui-front is needed for jquery autocomplete in the modal -->
-          <div id="movie_on_lists_<%= "#{movie.tmdb_id}" %>">
-            <%= render 'movies/movie_on_lists', movie: movie %>
-          </div>
-
-          <div id="movie_other_list_<%= "#{movie.tmdb_id}" %>">
-            <%= render 'movies/movie_add_to_another_list', movie: movie %>
-          </div>
-        </div><!-- partial-spacer -->
-
-        <% if @list.present? && current_user.all_lists.include?(@list) %>
-          <div class="partial-spacer">
-            <div id="list_priority_<%= "#{movie.tmdb_id}" %>">
-              <%= render 'movies/movie_list_priority', movie: movie %>
-            </div>
+<% if movie.in_db && movie.lists.by_user(current_user).present? %>
+  <div class="partial-spacer ui-front">
+    <!-- ui-front is needed for jquery autocomplete in the modal -->
+    <div id="movie_on_lists_<%= "#{movie.tmdb_id}" %>">
+      <%= render 'movies/movie_on_lists', movie: movie %>
     </div>
-          <% end %> <!-- #if @list.present? && current_user.all_lists.include?(@list)  -->
+
+    <div id="movie_other_list_<%= "#{movie.tmdb_id}" %>">
+      <%= render 'movies/movie_add_to_another_list', movie: movie %>
+    </div>
+  </div><!-- partial-spacer -->
+
+  <% if @list.present? && current_user.all_lists.include?(@list) %>
+    <div class="partial-spacer">
+      <div id="list_priority_<%= "#{movie.tmdb_id}" %>">
+        <%= render 'movies/movie_list_priority', movie: movie %>
+      </div>
+    </div>
+  <% end %> <!-- #if @list.present? && current_user.all_lists.include?(@list)  -->
 
 <% else %><!-- !movie.in_db or no user lists for movie -->
-        <div class="partial-spacer ui-front">
-          <!-- ui-front is needed for jquery autocomplete in the modal -->
-          <div id="movie_add_to_first_list_<%= "#{movie.tmdb_id}" %>">
-            <%= render 'movies/movie_add_to_first_list', movie: movie %>
-          </div>
+  <div class="partial-spacer ui-front">
+    <!-- ui-front is needed for jquery autocomplete in the modal -->
+    <div id="movie_add_to_first_list_<%= "#{movie.tmdb_id}" %>">
+      <%= render 'movies/movie_add_to_first_list', movie: movie %>
+    </div>
   </div>
-        <% end %><!-- movie.in_db && movie.lists.by_user -->
+<% end %><!-- movie.in_db && movie.lists.by_user -->
 
 <div class="partial-spacer">
   <div id="movie_show_seen_<%= "#{movie.tmdb_id}" %>" class="partial-spacer">
@@ -40,14 +40,18 @@
   </div>
 </div>
 
-        <div class="partial-spacer">
-          <div id="movie_rated_<%= "#{movie.tmdb_id}" %>">
-            <%= render 'movies/movie_rating', movie: movie %>
-          </div>
+<div class="partial-spacer">
+  <div id="movie_rated_<%= "#{movie.tmdb_id}" %>">
+    <%= render 'movies/movie_rating', movie: movie %>
+  </div>
 </div>
 
-        <div class="partial-spacer">
-           <div id="movie_reviewed_<%= "#{movie.tmdb_id}" %>">
-            <%= render 'movies/movie_review', movie: movie %>
-          </div>
-        </div> <!-- partial-spacer -->
+<div class="partial-spacer">
+  <div id="movie_reviewed_<%= "#{movie.tmdb_id}" %>">
+    <%= render 'movies/movie_review', movie: movie %>
+  </div>
+</div>
+
+<div class="partial-spacer">
+  <%= render "movies/movie_trailer", movie: @movie %>
+</div>

--- a/app/views/movies/_movie_production_companies.html.erb
+++ b/app/views/movies/_movie_production_companies.html.erb
@@ -1,0 +1,8 @@
+<% if @movie.production_companies.present? %>
+  <p><strong>Production Companies:</strong>
+    <% @movie.production_companies.each do |company| %>
+      <%= link_to "#{company[:name]}", discover_search_path(company: company[:id], sort_by: "release_date") %>
+      <%= ", " unless company == @movie.production_companies.last %>
+    <% end %>
+  </p>
+<% end %>

--- a/app/views/movies/_movie_production_companies.html.erb
+++ b/app/views/movies/_movie_production_companies.html.erb
@@ -1,5 +1,5 @@
 <% if @movie.production_companies.present? %>
-  <p><strong>Production Companies:</strong>
+  <p class='mt-5'><strong>Production Companies:</strong>
     <% @movie.production_companies.each do |company| %>
       <%= link_to "#{company[:name]}", discover_search_path(company: company[:id], sort_by: "release_date") %>
       <%= ", " unless company == @movie.production_companies.last %>

--- a/app/views/movies/_movie_rating.html.erb
+++ b/app/views/movies/_movie_rating.html.erb
@@ -4,8 +4,8 @@
 
     <p>
       <icon class="fa fa-heart"></icon>
-      <span class="pseudo-header"> My Enjoyment:</span> <%= movie.ratings.by_user(current_user).first.value %>/10 
-      <%= link_to '<i class="fa fa-pencil"></i> Edit Rating'.html_safe,
+      <span class="pseudo-header"> Your Enjoyment:</span> <%= movie.ratings.by_user(current_user).first.value %>/10
+      <%= link_to '<i class="fa fa-pencil"></i> Edit'.html_safe,
                   movie_rating_path(movie, movie.ratings.by_user(current_user).first),
                   id: "show_rating_link_movies_partial"
       %>

--- a/app/views/movies/_movie_show.html.erb
+++ b/app/views/movies/_movie_show.html.erb
@@ -60,36 +60,8 @@
         <!-- TRAILER & PRODUCTION COMPANIES -->
         <div class="row" id='trailer-section'>
           <div class="col-xs-12">
-
-            <% if @movie.trailer.present? %>
-              <div class="embed-container">
-                <iframe src="https://www.youtube.com/embed/<%= @movie.trailer %>?rel=0" allowfullscreen></iframe>
-              </div>
-            <% else %>
-              <p class="sidebar-button trailer-button">
-                <a href="https://www.youtube.com/results?search_query=<%= @movie.title %>+movie+official+trailer" target="_blank" alt="Search for the Trailer"><i class="fa fa-chevron-circle-right"></i> Watch the Trailer</a>
-              </p>
-            <% end %> <!-- #if trailer present -->
-
-          <% if current_user.admin? %>
-            <%= form_tag(movie_path(@movie), { class: "form-class", id: "add-trailer", method: :patch } ) do %>
-              <%= text_field_tag :trailer, nil,
-                                  { placeholder: trailer_placeholder_text(@movie),
-                                    class: 'form-control',
-                                    id: "trailer-text-field" } %>
-              <%= hidden_field_tag(:tmdb_id, @movie.tmdb_id) %>
-              <%= submit_tag trailer_button_text(@movie), id: "add-trailer-btn", class: "form-control-submit", disabled: 'disabled' %>
-            <% end %> <!-- # tag form loop -->
-          <% end %> <!-- # if admin? -->
-
-            <% if @movie.production_companies.present? %>
-              <p><strong>Production Companies:</strong>
-                <% @movie.production_companies.each do |company| %>
-                  <%= link_to "#{company[:name]}", discover_search_path(company: company[:id], sort_by: "release_date") %>
-                  <%= ", " unless company == @movie.production_companies.last %>
-                <% end %>
-              </p>
-            <% end %>
+            <%= render "movies/movie_trailer", movie: @movie %>
+            <%= render "movies/movie_production_companies", movie: @movie %>
           </div> <!-- col-xs-12 -->
         </div> <!-- row -->
 
@@ -124,5 +96,4 @@
       </div> <!-- col-xs-9 -->
     </div> <!-- movie-bottom-details -->
   </div> <!-- row -->
-
 </article>

--- a/app/views/movies/_movie_show_screening.html.erb
+++ b/app/views/movies/_movie_show_screening.html.erb
@@ -1,20 +1,21 @@
 
 <% if current_user.watched_movies.include?(@movie) %> <!-- #if movie has been seen -->
-  <h2>You've Seen this <%= pluralize(@movie.times_seen_by(current_user), "Time") %>.
-    Last seen on: <%= @movie.most_recent_screening_by(current_user) %>.
-  <span class="screening-link"><%= link_to "Add / Manage Screenings", movie_screenings_path(@movie), id: "add_screening_link_movies_partial" %></span>
-<% else %> <!-- #if movie has been seen -->
-  <h2>You Haven't Seen this One Yet!
-    <span class='screening-link'>
-      <%= link_to 'Mark as Watched', screenings_path(
-        screening: { location_watched: current_user.default_location },
-        tmdb_id: @movie.tmdb_id,
-        from: 'movies_index',
-        page: params[:page]
-      ),
-      method: :post,
-      id: 'mark_watched_link_movies_partial',
-      remote: true %>
+  <p>
+    <span class="material-symbols-outlined">videocam</span>
+    <span class="pseudo-header"> Last Watched:</span> <%= @movie.most_recent_screening_by(current_user) %>,
+    your <%= firstify_number(@movie.times_seen_by(current_user)) %> screening.
+    <span class="screening-link">
+      <%= link_to '<span class="material-symbols-outlined">edit</span>Edit'.html_safe,
+        movie_screenings_path(@movie),
+        id: "add_screening_link_movies_partial"
+      %>
     </span>
-  </h2>
+  </p>
+
+<% else %> <!-- #if movie has been seen -->
+  <p>
+    <span class="material-symbols-outlined">videocam</span>
+    <span class="pseudo-header"> Last Watched:</span> You haven't seen this one yet
+
+  </p>
 <% end %> <!-- #if movie has been seen -->

--- a/app/views/movies/_movie_trailer.html.erb
+++ b/app/views/movies/_movie_trailer.html.erb
@@ -1,0 +1,22 @@
+<% if movie.trailer.present? %>
+  <div class="embed-container">
+    <iframe src="https://www.youtube.com/embed/<%= movie.trailer %>?rel=0" allowfullscreen></iframe>
+  </div>
+<% else %>
+  <p class="sidebar-button trailer-button">
+    <a href="https://www.youtube.com/results?search_query=<%= movie.title %>+movie+official+trailer" target="_blank" alt="Search for the Trailer">
+      <i class="fa fa-chevron-circle-right"></i> Watch the Trailer
+    </a>
+  </p>
+<% end %> <!-- #if trailer present -->
+
+<% if current_user.admin? %>
+  <%= form_tag(movie_path(movie), { class: "form-class", id: "add-trailer", method: :patch } ) do %>
+    <%= text_field_tag :trailer, nil,
+                        { placeholder: trailer_placeholder_text(movie),
+                          class: 'form-control',
+                          id: "trailer-text-field" } %>
+    <%= hidden_field_tag(:tmdb_id, movie.tmdb_id) %>
+    <%= submit_tag trailer_button_text(movie), id: "add-trailer-btn", class: "form-control-submit", disabled: 'disabled' %>
+  <% end %> <!-- # tag form loop -->
+<% end %> <!-- # if admin? -->

--- a/lib/tmdb/client.rb
+++ b/lib/tmdb/client.rb
@@ -3,6 +3,8 @@
 module Tmdb
   module Client
     class Error < StandardError; end
+    require 'open-uri'
+
     # API Docs: https://developers.themoviedb.org/3/getting-started/introduction
     BASE_URL = 'https://api.themoviedb.org/3'
     API_KEY = ENV['tmdb_api_key']

--- a/spec/helpers/movies_helper_spec.rb
+++ b/spec/helpers/movies_helper_spec.rb
@@ -175,4 +175,38 @@ describe MoviesHelper, type: :helper do
       expect(runtime_display(movie)).to eq(nil)
     end
   end
+
+  describe 'firstify_number' do
+    it 'appends "st" to any number ending in 1' do
+      aggregate_failures 'numbers ending in 1' do
+        expect(firstify_number(1)).to eq('1st')
+        expect(firstify_number(21)).to eq('21st')
+        expect(firstify_number(301)).to eq('301st')
+      end
+    end
+
+    it 'appends "nd" to any number ending in 2' do
+      aggregate_failures 'numbers ending in 2' do
+        expect(firstify_number(2)).to eq('2nd')
+        expect(firstify_number(42)).to eq('42nd')
+        expect(firstify_number(302)).to eq('302nd')
+      end
+    end
+
+    it 'appends "rd" to any number ending in 3' do
+      aggregate_failures 'numbers ending in 3' do
+        expect(firstify_number(3)).to eq('3rd')
+        expect(firstify_number(43)).to eq('43rd')
+        expect(firstify_number(303)).to eq('303rd')
+      end
+    end
+
+    it 'handles outliers in the teens (11, 12, 13)' do
+      aggregate_failures 'numbers ending in 2' do
+        expect(firstify_number(111)).to eq('111th')
+        expect(firstify_number(212)).to eq('212th')
+        expect(firstify_number(313)).to eq('313th')
+      end
+    end
+  end
 end

--- a/spec/helpers/movies_helper_spec.rb
+++ b/spec/helpers/movies_helper_spec.rb
@@ -77,24 +77,24 @@ describe MoviesHelper, type: :helper do
   describe 'trailer placeholder text' do
     it 'renders correct placeholder text for a movie with a trailer' do
       allow(movie).to receive(:trailer).and_return('trailerlink')
-      expect(helper.trailer_placeholder_text(movie)).to include('change the trailer')
+      expect(helper.trailer_placeholder_text(movie)).to include('Change')
     end
 
     it 'renders correct placeholder text for a movie without a trailer' do
       allow(movie).to receive(:trailer).and_return(nil)
-      expect(helper.trailer_placeholder_text(movie)).to include('add a trailer')
+      expect(helper.trailer_placeholder_text(movie)).to include('Add')
     end
   end
 
   describe 'trailer button text' do
     it 'renders correct button text for a movie with a trailer' do
       allow(movie).to receive(:trailer).and_return('trailerlink')
-      expect(helper.trailer_button_text(movie)).to eq('Change trailer')
+      expect(helper.trailer_button_text(movie)).to eq('Change')
     end
 
     it 'renders correct button text for a movie without a trailer' do
       allow(movie).to receive(:trailer).and_return(nil)
-      expect(helper.trailer_button_text(movie)).to eq('Add a trailer')
+      expect(helper.trailer_button_text(movie)).to eq('+ Add')
     end
   end
 


### PR DESCRIPTION
## Related Issues & PRs
Closes #346 

## Problems Solved
We were missing some details from the modal like we like seeing on the "show" page, so this PR adds these items to the modal:
* the most recent screening date
* the number of times watched
* the trailer
* for admin users, the ability to add/update the trailer url

We also updated some existing features:
* the "add a trailer" field has more concise language and the form is now on one line
* the screenings information is reworded and no longer includes a link to add screenings

## Screenshots
The red arrows are on the screenshots to indicate places where changes were made.

| Before | After |
|--|--|
| <img width="375" alt="Screen Shot 2023-01-08 at 2 52 39 PM" src="https://user-images.githubusercontent.com/8680712/211219027-c8e17a9e-12de-4ece-ab98-15fab6044740.png">| <img width="375" alt="Screen Shot 2023-01-08 at 2 52 23 PM" src="https://user-images.githubusercontent.com/8680712/211219089-1df45972-572c-47a3-a03a-be656f351456.png"> |

| Before | After |
|--|--|
| <img width="375" alt="Screen Shot 2023-01-08 at 2 54 19 PM" src="https://user-images.githubusercontent.com/8680712/211218969-4be5f475-a3a6-4e28-a8c5-61a711c9f2f3.png"> | <img width="375" alt="Screen Shot 2023-01-08 at 2 54 04 PM" src="https://user-images.githubusercontent.com/8680712/211218965-03e82cf3-7acf-4578-9dbe-0f2c9e065fcd.png">|

## Other Stuff
In addition to these feature changes, I also resolved an error where we were getting a "private method `open` on URI" error. I'm not sure why this works in production but not locally anymore, 😕 but now it should work everywhere. 

Ans lastly, I prepended all of my commits with the issue number, as to be a better citizen of this repo.

