### PR TITLE
Add last-watched date and count to seen-movies section of actor bio

### DIFF
--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -76,14 +76,38 @@ class TmdbController < ApplicationController
     end
   end
 
+  # def actor_more
+  #   actor_data = PersonDataService.get_person_profile_data(params[:actor_id])
+  #   movies_seen = current_user.watched_movies.pluck(:tmdb_id)
+  #   actor_movies_seen = actor_data.movie_credits.actor.select { |m| movies_seen.include?(m.tmdb_id) }
+
+  #   @data = OpenStruct.new(
+  #     actor: actor_data,
+  #     movies_seen: actor_movies_seen
+  #   )
+  # end
+
   def actor_more
     actor_data = PersonDataService.get_person_profile_data(params[:actor_id])
-    movies_seen = current_user.watched_movies.pluck(:tmdb_id)
-    actor_movies_seen = actor_data.movie_credits.actor.select { |m| movies_seen.include?(m.tmdb_id) }
+    actor_movie_ids = actor_data.movie_credits.actor.map { |m| m.tmdb_id }
+    user_movies_seen = current_user.watched_movies.where(tmdb_id: actor_movie_ids).uniq
+
+    movies_seen = user_movies_seen.map do |movie|
+      credit = actor_data.movie_credits.actor.find { |m| m.tmdb_id == movie.tmdb_id }
+      {
+        movie_id: movie.id,
+        release_year: credit.date,
+        title: movie.title,
+        character: credit.character,
+        birthday: actor_data.profile.birthday,
+        last_watched_date: movie.most_recent_screening_by(current_user)
+      }
+    end
+
 
     @data = OpenStruct.new(
       actor: actor_data,
-      movies_seen: actor_movies_seen
+      movies_seen: movies_seen
     )
   end
 

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -76,23 +76,12 @@ class TmdbController < ApplicationController
     end
   end
 
-  # def actor_more
-  #   actor_data = PersonDataService.get_person_profile_data(params[:actor_id])
-  #   movies_seen = current_user.watched_movies.pluck(:tmdb_id)
-  #   actor_movies_seen = actor_data.movie_credits.actor.select { |m| movies_seen.include?(m.tmdb_id) }
-
-  #   @data = OpenStruct.new(
-  #     actor: actor_data,
-  #     movies_seen: actor_movies_seen
-  #   )
-  # end
-
   def actor_more
     actor_data = PersonDataService.get_person_profile_data(params[:actor_id])
     actor_movie_ids = actor_data.movie_credits.actor.map { |m| m.tmdb_id }
     user_movies_seen = current_user.watched_movies.where(tmdb_id: actor_movie_ids).uniq
 
-    movies_seen = user_movies_seen.map do |movie|
+    seen_movie_details = user_movies_seen.map do |movie|
       credit = actor_data.movie_credits.actor.find { |m| m.tmdb_id == movie.tmdb_id }
       {
         movie_id: movie.id,
@@ -107,7 +96,7 @@ class TmdbController < ApplicationController
 
     @data = OpenStruct.new(
       actor: actor_data,
-      movies_seen: movies_seen
+      movies_seen: seen_movie_details
     )
   end
 

--- a/app/views/tmdb/_seen_movie_credits.html.erb
+++ b/app/views/tmdb/_seen_movie_credits.html.erb
@@ -1,6 +1,6 @@
 <% if movies_seen.any? %>
   <h3>
-    Movies I've Seen
+    Movies You've Seen (<%= movies_seen.length %>)
   </h3>
   <ul>
     <% movies_seen.each do |credit| %>

--- a/app/views/tmdb/_seen_movie_credits.html.erb
+++ b/app/views/tmdb/_seen_movie_credits.html.erb
@@ -5,10 +5,11 @@
   <ul>
     <% movies_seen.each do |credit| %>
       <li>
-        <%= link_to credit.title, movie_more_path(tmdb_id: "#{credit.tmdb_id}") %>
-        <%= "| #{credit.date}" if credit.date != "Date unavailable" %>
-        <%= display_actor_age_at_release(person_profile.birthday, credit.date) %>
-        <%= "as #{credit.character}" if credit.character.present? %>
+        <%= link_to credit[:title], movie_path(credit[:movie_id]) %>
+        <%= "| #{credit[:release_year]}" if credit[:release_year] != "Date unavailable" %>
+        <%= display_actor_age_at_release(credit[:birthday], credit[:release_year]) %>
+        <%= "as #{credit[:character]}" if credit[:character].present? %>
+        | <span class='material-symbols-outlined'>videocam</span> <%= credit[:last_watched_date] %>
       </li>
     <% end %>
   </ul>

--- a/app/views/tmdb/actor_more.html.erb
+++ b/app/views/tmdb/actor_more.html.erb
@@ -14,7 +14,7 @@
     <div class="credits">
       <%= render partial: "movie_credits", locals: { person_profile: @data.actor.profile, movie_credits: @data.actor.movie_credits } %>
 
-      <%= render partial: "seen_movie_credits", locals: { person_profile: @data.actor.profile, movies_seen: @data.movies_seen } %>
+      <%= render partial: "seen_movie_credits", locals: { movies_seen: @data.movies_seen } %>
 
       <%= render partial: "tv_credits", locals: { tv_credits: @data.actor.tv_credits, actor_id: @data.actor.person_id }  %>
 


### PR DESCRIPTION
## Related Issues & PRs
Closes #313

## Problems Solved
This PR adds more data to the seen-movies section of the actor bio. This way, we'll have more context when looking at that list of movies and know the answer to the questions:
* when did I see this movie last?
* how many movies have I seen with this actor in it? 

## Screenshots
| Before | After |
|---|---|
|  <img width="515" alt="Screen Shot 2023-01-09 at 2 10 28 PM" src="https://user-images.githubusercontent.com/8680712/211399067-114ec971-cd51-4470-b336-ebdea7c00ecd.png"> |<img width="535" alt="Screen Shot 2023-01-09 at 2 09 22 PM" src="https://user-images.githubusercontent.com/8680712/211399103-803f60a9-864e-428e-830b-baaa6c44f933.png"> |

## Performance Concerns
Getting this new data was not particularly costly. For the count of movies I've sen, it's just a `.length` on an array. For adding the last-watched date, I'm adding a db lookup for each movie. This could be costly, but the reality of it is that this dataset will always be small. I doubt either of us will ever have seen any more than 20 movies that a specific actor has been in. So it really doesn't concern me. I started looking into some  fancier querying, but since I also had to consider the data coming from the API, it just seemed to get complicated and the juice didn't seem worth the squeeze.

