### PR TITLE
Fix streaming service providers on mobile and update amazon links

### DIFF
--- a/app/services/streaming_service_provider_data_service.rb
+++ b/app/services/streaming_service_provider_data_service.rb
@@ -22,12 +22,12 @@ module StreamingServiceProviderDataService
         {
           name: 'Amazon Prime Video',
           pay_model: 'try',
-          url: "https://smile.amazon.com/s?k=#{parameterized_title}&i=instant-video"
+          url: "https://www.amazon.com/s?k=#{parameterized_title}&i=instant-video"
         },
         {
           name: 'Amazon Video',
           pay_model: 'try',
-          url: "https://smile.amazon.com/s?k=#{parameterized_title}&i=instant-video"
+          url: "https://www.amazon.com/s?k=#{parameterized_title}&i=instant-video"
         },
         {
           name: 'YouTube',

--- a/app/views/tmdb/tv_series.html.erb
+++ b/app/views/tmdb/tv_series.html.erb
@@ -1,4 +1,4 @@
-<article id="profile">
+<article id="profile" class='movie-show'>
   <div class="row">
     <div class="col-xs-12">
       <div class="summary-box">
@@ -15,35 +15,43 @@
   </div> <!-- row -->
 
   <div class="row">
-    <div class="col-xs-3">
-      <div class="sidebar">
-        <%= render "shared/streaming_service_providers", streaming_service_providers: @series.streaming_service_providers %>
+    <div class="movie-bottom-details">
+      <div class="col-xs-3">
+        <div class="sidebar">
+            <div class="mobile">
+            <%= render "shared/streaming_service_providers", streaming_service_providers: @series.streaming_service_providers %>
+          </div>
+        </div>
       </div>
     </div>
 
     <div class="col-xs-9">
-      <div class="tv-credits">
-        <% if @series.seasons.present? %>
-          <h2>Seasons: |
-            <% @series.seasons.each do |season| %>
-            <%= link_to season_number_display(season), tv_season_path(show_id: @series.show_id, season_number: season, show_name: @series.show_name) %> |
-            <% end %>
-          </h2>
-        <% end %><!-- if @series.seasons.present? -->
+      <div class="row">
+        <div class="col-xs-12">
+          <div class="tv-credits">
+            <% if @series.seasons.present? %>
+              <h2>Seasons: |
+                <% @series.seasons.each do |season| %>
+                <%= link_to season_number_display(season), tv_season_path(show_id: @series.show_id, season_number: season, show_name: @series.show_name) %> |
+                <% end %>
+              </h2>
+            <% end %><!-- if @series.seasons.present? -->
 
-        <% if @series.actors.present? %>
-          <h2>Show Cast:</h2>
-          <% @series.actors.each do |actor| %>
-            <div class="headshot-container">
-              <%= headshot_for(actor) %>
-              <div class="name-block">
-                <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}")) %></p>
-                <p>as <%= truncate(actor.character_name, length: 18, escape: false) %><p>
-              </div> <!-- name-block -->
-            </div> <!-- headshot-container -->
-          <% end %><!-- actors each do -->
-        <% end %><!-- if @series.actors.present? -->
-      </div>
-    </div> <!-- credits -->
-  </div> <!-- row -->
+            <% if @series.actors.present? %>
+              <h2>Show Cast:</h2>
+              <% @series.actors.each do |actor| %>
+                <div class="headshot-container">
+                  <%= headshot_for(actor) %>
+                  <div class="name-block">
+                    <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}")) %></p>
+                    <p>as <%= truncate(actor.character_name, length: 18, escape: false) %><p>
+                  </div> <!-- name-block -->
+                </div> <!-- headshot-container -->
+              <% end %><!-- actors each do -->
+            <% end %><!-- if @series.actors.present? -->
+          </div>
+        </div> <!-- col 12 -->
+      </div> <!-- row -->
+    </div> <!-- col 9 -->
+  </div> <!-- row  with sidebar -->
 </article>


### PR DESCRIPTION
## Related Issues & PRs
Closes Change AmazonSmile service provider links to regular Amazon #359 
Closes Fix streaming service providers for TV on mobile #362 

## Problems Solved
* Amazon will discontinue its "smile" program, so the streaming service provider links we have needed to change from `https://smile.amazon.com` to `https://www.amazon.com`
* I neglected to check the mobile layout when I implemented the streaming service provider feature in #356 . This PR fixes that. 

| Before | After |
|---|---|
| <img width="390" alt="before" src="https://user-images.githubusercontent.com/8680712/213471328-d6912fb5-82d7-4dd5-907b-b363dda46641.png"> | <img width="390" alt="after" src="https://user-images.githubusercontent.com/8680712/213470478-515685bc-5cf9-4b8e-9c8c-2138a8654930.png"> |
