### PR TITLE
Resolve blank form sentry errors

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -38,7 +38,7 @@ class MoviesController < ApplicationController
 
   def show
     @media = Movie.friendly.find(params[:id])
-    return redirect_to movie, status: :moved_permanently if request.path != movie_path(@media)
+    return redirect_to movie_path(@media), status: :moved_permanently if request.path != movie_path(@media)
 
     render 'shared/media_profile'
   end

--- a/app/views/tmdb/actor_search.html.erb
+++ b/app/views/tmdb/actor_search.html.erb
@@ -3,8 +3,17 @@
 <h1>Search by Actor</h1>
 <% if @results&.actor.blank? %> <!-- Display the search form -->
   <%= form_tag '/tmdb/actor_search', { class: "form-class", id: "actor-search", role: "form", method: :get } do %>
-    <%= text_field_tag :actor, nil, class: "form-control search-form autocomplete-search-field", id: "actor_name_actor_search", placeholder: "Enter Actor Name", data: { autocomplete_source: person_autocomplete_path } %>
-    <%= select_tag :sort_by, options_for_select(MovieDataService::SORT_BY), {:prompt => "Sort by...", class: "form-control search-form", :include_blank => false } %>
+    <%= text_field_tag :actor, nil,
+      class: "form-control search-form autocomplete-search-field",
+      id: "actor_name_actor_search",
+      required: true,
+      placeholder: "Enter Actor Name",
+      data: { autocomplete_source: person_autocomplete_path }
+    %>
+    <%= select_tag :sort_by,
+      options_for_select(MovieDataService::SORT_BY),
+      { prompt: "Sort by...", class: "form-control search-form", include_blank: false }
+    %>
     <%= submit_tag "Search", id: "submit_button_actor_search", class: "form-control-submit search-form-submit" %>
   <% end %>
 <% end %>

--- a/app/views/tmdb/search.html.erb
+++ b/app/views/tmdb/search.html.erb
@@ -1,29 +1,37 @@
 <% content_for(:title, "Search by Movie Title") %>
 
-<% if !@movie_title.present? %>
+<% if @movie_title.blank? %>
   <h1 id="search_by_title_header">Search for a Movie by Title</h1>
-  <%= form_tag '/tmdb/search', { class: "form-class", id: "movie-title-search", role: "form", method: :get } do %>
-    <%= text_field_tag :movie_title, nil, class: "form-control search-form search-form autocomplete-auto-submit", id: "movie_field_movie_search", placeholder: "Enter Movie Title", data: { autocomplete_source: movie_autocomplete_path }  %>
+  <%= form_tag '/tmdb/search', { class: "form-class mb-10", id: "movie-title-search", role: "form", method: :get } do %>
+    <%= text_field_tag :movie_title, nil,
+      class: "form-control search-form search-form autocomplete-auto-submit",
+      id: "movie_field_movie_search",
+      required: true,
+      placeholder: "Enter Movie Title",
+      data: { autocomplete_source: movie_autocomplete_path }
+    %>
     <%= submit_tag "Search", id: "search_by_title_button", class: "form-control-submit search-form-submit" %>
   <% end %>
-  <br>
 
 <% else %>
-
   <% if @search_results.not_found_message.present? %>
     <h2>Hmm. <%= @search_results.not_found_message %></h2>
     <p>Check your spelling and try again.</p>
     <p class="button-main"><%= link_to "Search Again", api_search_path %> </p>
 
   <% else %> <!-- # if @search_results.not_found_message.present? -->
-    <h2>Movies matching '<%= @search_results.query %>'</h2>
+    <h2 class="mb-10">Movies matching '<%= @search_results.query %>'</h2>
 
-    <br>
-      <%= form_tag '/tmdb/search', { class: "form-class", id: "movie-title-search-again", role: "form", method: :get } do %>
-        <%= text_field_tag :movie_title, nil, class: "form-control search-form autocomplete-auto-submit", id: "movie_field_movie_search_again", placeholder: "Enter movie title", data: { autocomplete_source: movie_autocomplete_path }  %>
-        <%= submit_tag "Search Again", id: "search_by_title_again_button", class: "form-control-submit search-form-submit" %>
-      <% end %>
-    </br>
+    <%= form_tag '/tmdb/search', { class: "form-class mb-10", id: "movie-title-search-again", role: "form", method: :get } do %>
+      <%= text_field_tag :movie_title, nil,
+        class: "form-control search-form autocomplete-auto-submit",
+        id: "movie_field_movie_search_again",
+        required: true,
+        placeholder: "Enter movie title",
+        data: { autocomplete_source: movie_autocomplete_path }
+      %>
+      <%= submit_tag "Search Again", id: "search_by_title_again_button", class: "form-control-submit search-form-submit" %>
+    <% end %>
 
     <div id ="movies_search_loop">
       <%= render partial: 'movies/movie_partial_loop', locals: { movies: @search_results.movies } %>

--- a/app/views/tmdb/tv_series_search.html.erb
+++ b/app/views/tmdb/tv_series_search.html.erb
@@ -5,7 +5,9 @@
   <%= text_field_tag :show_title, nil,
     class: "form-control search-form autocomplete-auto-submit",
     placeholder: "Enter TV Show Title",
-    data: { autocomplete_source: tv_series_autocomplete_path }  %>
+    required: true,
+    data: { autocomplete_source: tv_series_autocomplete_path }
+  %>
   <%= submit_tag "Search", id: "submit_button_tv_series_search", class: "form-control-submit search-form-submit" %>
 <% end %>
 <br>

--- a/app/views/tmdb/two_actor_search.html.erb
+++ b/app/views/tmdb/two_actor_search.html.erb
@@ -8,8 +8,20 @@
     <p>Enter two actors to see the movies they've been in together.</p>
   <% end %>
   <%= form_tag '/tmdb/two_actor_search', { class: "form-class", id: "two-actor-search", role: "form", method: :get } do %>
-    <%= text_field_tag :actor, nil, class: "form-control search-form autocomplete-search-field", id: "actor1_field_two_actor_search", placeholder: "Enter Actor One's Name", data: { autocomplete_source: person_autocomplete_path } %>
-    <%= text_field_tag :actor2, nil, class: "form-control search-form autocomplete-search-field", id: "actor2_field_two_actor_search", placeholder: "Enter Actor Two's Name", data: { autocomplete_source: person_autocomplete_path } %>
+    <%= text_field_tag :actor, nil,
+      class: "form-control search-form autocomplete-search-field",
+      id: "actor1_field_two_actor_search",
+      required: true,
+      placeholder: "Enter Actor One's Name",
+      data: { autocomplete_source: person_autocomplete_path }
+    %>
+    <%= text_field_tag :actor2, nil,
+      class: "form-control search-form autocomplete-search-field",
+      id: "actor2_field_two_actor_search",
+      required: true,
+      placeholder: "Enter Actor Two's Name",
+      data: { autocomplete_source: person_autocomplete_path }
+    %>
     <%= submit_tag "Search", id: "search_button_two_actor_search", class: "form-control-submit search-form-submit" %>
   <% end %>
 

--- a/app/views/tmdb/two_movie_search.html.erb
+++ b/app/views/tmdb/two_movie_search.html.erb
@@ -3,8 +3,20 @@
 <% if @search_results.nil? %>
   <p>Enter two movies and see which actors have been in both movies.</p>
   <%= form_tag '/tmdb/two_movie_search', { class: "form-class", id: "two-movie-search", role: "form", method: :get } do %>
-    <%= text_field_tag :movie_one, nil, class: "form-control search-form autocomplete-search-field", id: "movie1_field_two_movie_search", placeholder: "Enter Movie Title", data: { autocomplete_source: movie_autocomplete_path }  %>
-    <%= text_field_tag :movie_two, nil, class: "form-control search-form autocomplete-search-field", id: "movie2_field_two_movie_search", placeholder: "Enter Movie Title", data: { autocomplete_source: movie_autocomplete_path }  %>
+    <%= text_field_tag :movie_one, nil,
+      class: "form-control search-form autocomplete-search-field",
+      id: "movie1_field_two_movie_search",
+      required: true,
+      placeholder: "Enter Movie Title",
+      data: { autocomplete_source: movie_autocomplete_path }
+    %>
+    <%= text_field_tag :movie_two, nil,
+      class: "form-control search-form autocomplete-search-field",
+      id: "movie2_field_two_movie_search",
+      required: true,
+      placeholder: "Enter Movie Title",
+      data: { autocomplete_source: movie_autocomplete_path }
+    %>
     <%= submit_tag "Search", id: "search_button_two_movie_search", class: "form-control-submit search-form-submit" %>
   <% end %>
 

--- a/lib/tmdb/client.rb
+++ b/lib/tmdb/client.rb
@@ -11,7 +11,7 @@ module Tmdb
 
     class << self
       def request(endpoint, params)
-        return { results: [] } if params[:query].present? && searchable_query(params[:query]).empty?
+        return { results: [] } if invalid_params?(params)
 
         api_path = build_url(endpoint, params)
         response = URI.open("#{BASE_URL}#{api_path}").read
@@ -59,8 +59,15 @@ module Tmdb
         api_path
       end
 
+      def invalid_params?(params)
+        # The :query key does not have to be present, but if it is present, it has to be valid
+        params.blank? ||
+        params[:query] == '' ||
+        (params[:query].present? && searchable_query(params[:query]).empty?)
+      end
+
       def searchable_query(query)
-        return unless query.present?
+        return nil unless query.present?
         # If a user searches for a name that starts with an `&` the api call fails.
         # This ensures no non alphanumeric characters make it into the query string.
         I18n.transliterate(query).gsub(/[^0-9a-z ]/i, '')

--- a/spec/lib/tmdb/client_spec.rb
+++ b/spec/lib/tmdb/client_spec.rb
@@ -3,6 +3,52 @@
 require 'rails_helper'
 
 RSpec.describe Tmdb::Client do
+  describe 'request' do
+    let(:empty_result_set) { { results: [] } }
+
+    describe 'when there are empty params provided' do
+      it 'returns an empty result set' do
+        expect(Tmdb::Client.request('foo_endpoint', {})).to eq(empty_result_set)
+      end
+    end
+
+    describe 'when there are no params provided' do
+      it 'returns an empty result set' do
+        expect(Tmdb::Client.request('foo_endpoint', nil)).to eq(empty_result_set)
+      end
+    end
+
+    describe 'when :query params key is present' do
+      describe 'and the value is an empty string' do
+        it 'returns an empty result set' do
+          expect(Tmdb::Client.request('foo_endpoint', { query: '' })).to eq(empty_result_set)
+        end
+      end
+
+      describe 'and the string has searchable characters' do
+        it 'makes the request' do
+          params = { query: 'Sandra Bullock' }
+          allow(JSON).to receive(:parse).and_return('success')
+          expect(Tmdb::Client.request('foo_endpoint', params)).to eq('success')
+        end
+      end
+
+      describe 'but the string does not contain searchable characters' do
+        it 'returns an empty result set' do
+          expect(Tmdb::Client.request('foo_endpoint', { query: '&!*' })).to eq(empty_result_set)
+        end
+      end
+    end
+
+    describe 'when keys other than :query are present' do
+      params = { people: 18277, page: nil, sort_by: "" }
+      it 'makes the request' do
+        allow(JSON).to receive(:parse).and_return('success')
+        expect(Tmdb::Client.request('foo_endpoint', params)).to eq('success')
+      end
+    end
+  end
+
   describe 'private.build_url' do
     context 'when a user searches for a bunch non-alphanumeric characters as a query string' do
       let(:searched_string) { '&^%$#@#$%' }


### PR DESCRIPTION
## Related Issues & PRs
* [TMDB-MOVIEQUEUE-6Z](https://mike-vallano.sentry.io/issues/3901921697/?project=127874&query=is%3Aunresolved&referrer=issue-stream)
* [TMDB-MOVIEQUEUE-70](https://mike-vallano.sentry.io/issues/3904770136/?project=127874&query=is%3Aunresolved&referrer=issue-stream)

## Problems Solved
1. We were getting an undefined variable error in the `movies#show` action because I missed switching it over from `movie` to `@media` in my last PR #365.

2. We discovered that we did not have any error handling for when a user submits an empty string to any of the searches:
  * movie by title
  * actor by name
  * tv series by name
  * movies between two actors
  * actors between two movies
  To resolve this, I added handling and specs for the handling of empty strings at the `Tmdb::Client` level. I also added `required: true` to all of the form fields that are indeed required. This prevents us from even getting to the error handling in the `Tmdb::Client`.

## Screenshots
Now all of the form fields have this little error text (courtesy of default HTML behavior) if a user submits an empty form.
<img width="723" alt="Screen Shot 2023-01-30 at 10 15 28 AM" src="https://user-images.githubusercontent.com/8680712/215539414-d2cb87ab-b881-4d39-be89-a5f22657ab8e.png">

