### PR TITLE
367: Remove coveralls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem 'friendly_id'
 gem 'httparty'
 gem 'rails_12factor', group: :production
 gem 'will_paginate'
-gem 'coveralls', '0.8.11', require: false
 gem 'rack-mini-profiler'
 gem 'stamp'
 gem 'sentry-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,12 +72,6 @@ GEM
     choice (0.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
-    coveralls (0.8.11)
-      json (~> 1.8)
-      simplecov (~> 0.11.0)
-      term-ansicolor (~> 1.3)
-      thor (~> 0.19.1)
-      tins (~> 1.6.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -95,7 +89,6 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
-    docile (1.1.5)
     erubi (1.11.0)
     execjs (2.8.1)
     factory_bot (6.2.1)
@@ -302,11 +295,6 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (5.2.0)
       activesupport (>= 5.2.0)
-    simplecov (0.11.2)
-      docile (~> 1.1.0)
-      json (~> 1.8)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -315,13 +303,10 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     stamp (0.6.0)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
     terminal-notifier-guard (1.7.0)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.11)
-    tins (1.6.0)
     tzinfo (1.2.10)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -358,7 +343,6 @@ DEPENDENCIES
   binding_of_caller
   capybara
   capybara-email
-  coveralls (= 0.8.11)
   database_cleaner
   devise
   factory_bot_rails

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Flicks On Lists
 
-[![Build Status](https://travis-ci.org/mikevallano/tmdb-moviequeue.svg?branch=master)](https://travis-ci.org/mikevallano/tmdb-moviequeue) [![Code Climate](https://codeclimate.com/github/mikevallano/tmdb-moviequeue/badges/gpa.svg)](https://codeclimate.com/github/mikevallano/tmdb-moviequeue) [![Coverage Status](https://coveralls.io/repos/github/mikevallano/tmdb-moviequeue/badge.svg?branch=master)](https://coveralls.io/github/mikevallano/tmdb-moviequeue?branch=master)
+[![Build Status](https://travis-ci.org/mikevallano/tmdb-moviequeue.svg?branch=master)](https://travis-ci.org/mikevallano/tmdb-moviequeue)
+[![Code Climate](https://codeclimate.com/github/mikevallano/tmdb-moviequeue/badges/gpa.svg)](https://codeclimate.com/github/mikevallano/tmdb-moviequeue)
 
 ## This Rails app helps movie viewing in a few ways:
 

--- a/coveralls.yml
+++ b/coveralls.yml
@@ -1,2 +1,0 @@
-service_name: travis-ci
-repo_token: ENV["coveralls_repo_token"]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,8 +8,6 @@ require 'rspec/rails'
 
 
 # Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
-require 'coveralls'
-Coveralls.wear!('rails')
 require 'devise'
 require 'shoulda/matchers'
 require 'support/controller_helpers'


### PR DESCRIPTION
## Related Issues & PRs
Closes #367 

## Problems Solved
* Just removes coveralls, which does an analysis and tells you how much of your code has test coverage. It was saying we have like 34% or something, which is not accurate.

Anyway, they stopped offering their free tier, so I thought we should just remove it

## Screenshots
Before:
<img width="430" alt="coveralls-before" src="https://user-images.githubusercontent.com/7945260/216470870-9fe2be15-a6a4-4c27-9ff7-bd85c66a6021.png">
After:
<img width="527" alt="coveralls-after" src="https://user-images.githubusercontent.com/7945260/216470873-fd99f061-3e80-4f98-9e64-0c397529e180.png">

## Things Learned
* I learned I don't know how coveralls works, because we have way better than 34% coverage
