### PR TITLE
Add margin right to list and tag delete icons

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,8 +2,10 @@
 <html>
   <head>
     <title><%= raw page_title %></title>
-    <link href='https://fonts.googleapis.com/css?family=Nixie+One|Open+Sans:400,600,700' rel='stylesheet' type='text/css'>
+    <!-- Bootstrap 3.0.2 -->
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.2/css/bootstrap.min.css">
+    <!-- Google Fonts -->
+    <link href='https://fonts.googleapis.com/css?family=Nixie+One|Open+Sans:400,600,700' rel='stylesheet' type='text/css'>
     <!-- Material Icons and Material Symbols are different. This stylesheet only accesses Material Symbols.
     To use Material Symbols, it will require a little more set up. -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" />

--- a/app/views/movies/_movie_on_lists.html.erb
+++ b/app/views/movies/_movie_on_lists.html.erb
@@ -1,5 +1,14 @@
-  <p><icon class="fa fa-list-ul"></icon><span class="pseudo-header"> Lists:</span>
-    <% movie.lists.by_user(current_user).each do |list| %>
-      <%= link_to "  #{list.name} ", user_list_path(list.owner, list.slug), id: "show_list_link_on_list_movies_partial" %><%= link_to "", delete_listing_path(list.id, movie.id), id: "remove_movie_link_movies_partial", method: :delete, remote: true, data: { confirm: "You are taking this movie out of your " + list.name + " list. Are you sure you want to do that?" }, class: "fa fa-times-circle" %>
-    <% end %> <!-- # list loop -->
+<p><icon class="fa fa-list-ul"></icon><span class="pseudo-header"> Lists:</span>
+  <% movie.lists.by_user(current_user).each do |list| %>
+   <%= link_to "  #{list.name} ",
+      user_list_path(list.owner, list.slug),
+      id: "show_list_link_on_list_movies_partial" %>
+    <%= link_to "", delete_listing_path(list.id, movie.id),
+      id: "remove_movie_link_movies_partial",
+      class: "fa fa-times-circle mr-5",
+      method: :delete,
+      remote: true,
+      data: { confirm: "You are taking this movie out of your " + list.name + " list. Are you sure you want to do that?" } %>
+  <% end %> <!-- # list loop -->
+</p>
 

--- a/app/views/movies/_movie_tag.html.erb
+++ b/app/views/movies/_movie_tag.html.erb
@@ -1,29 +1,40 @@
-  <p><icon class="fa fa-tags"></icon><span class="pseudo-header"> Tags:</span>
+<p>
+  <icon class="fa fa-tags"></icon>
+  <span class="pseudo-header"> Tags:</span>
   <% if movie.tags.present? %>
     <% if @list.present? && current_user.all_lists.include?(@list) %> <!-- # shared list logic -->
       <% movie.tags.by_user_or_list(@list).each do |tag| %>
-        <%= link_to "#{tag.name}", tag_path(tag.name, list_id: @list.id), id: "tag_link_movies_partial" %>
-        <% if current_user.tags.include?(tag) %> <!-- #users can only delete their own tags -->
-          </icon><%= link_to "", delete_tagging_path(tag.id, movie.id, list_id: @list.id, page: params[:page]), id: "remove_tag_link_movies_partial_on_list", method: :delete, remote: true, class: "fa fa-times-circle"  %>
-        <% end %> <!-- #if current_user.tags.include?(tag) -->
+        <%= link_to "#{tag.name}",
+          tag_path(tag.name,
+          list_id: @list.id),
+          id: "tag_link_movies_partial" %>
+        <%= link_to "",
+          delete_tagging_path(tag.id, movie.id, list_id: @list.id, page: params[:page]),
+          id: "remove_tag_link_movies_partial_on_list",
+          method: :delete,
+          remote: true,
+          class: "fa fa-times-circle mr-5" if current_user.tags.include?(tag) %>
       <% end %> <!-- #tag loop -->
-
-    <% else %><!-- # shared list logic -->
+    <% else %><!-- # shared list logic else -->
       <% movie.tags.by_user_or_list(current_user).each do |tag| %>
         <%= link_to "#{tag.name}", tag_path(tag.name), id: "tag_link_movies_partial" %>
-        </icon><%= link_to "", delete_tagging_path(tag.id, movie.id, page: params[:page]), id: "remove_tag_link_movies_partial", method: :delete, remote: true, class: "fa fa-times-circle" %>
-        <% end %> <!-- #tag loop -->
-
+          <%= link_to "",
+          delete_tagging_path(tag.id, movie.id, page: params[:page]),
+          id: "remove_tag_link_movies_partial",
+          method: :delete,
+          remote: true,
+          class: "fa fa-times-circle mr-5" %>
+      <% end %> <!-- #tag loop -->
     <% end %><!-- # shared list logic -->
   <% end %> <!-- # if tags.present? -->
-  </p>
+</p>
 
-    <%= form_tag( { :controller => :taggings, :action => :create }, { class: "form-class", id: "tag-form-modal", remote: true } ) do %>
-      <%= text_field_tag :tag_list, nil, { placeholder: "Separate by commas", class: 'form-control', id: "tag-list-modal" } %>
-      <%= hidden_field_tag(:tmdb_id, movie.tmdb_id) %>
-      <%= hidden_field_tag(:list_id, @list.id) if @list.present? && current_user.all_lists.include?(@list) %>
-      <%= hidden_field_tag(:page, params[:page]) %>
-      <%= submit_tag "+ Add", id: "add_tags_button_movies_partial", class: "form-control-submit" %>
-    <% end %> <!-- # tag form loop -->
+<%= form_tag( { :controller => :taggings, :action => :create }, { class: "form-class", id: "tag-form-modal", remote: true } ) do %>
+  <%= text_field_tag :tag_list, nil, { placeholder: "Separate by commas", class: 'form-control', id: "tag-list-modal" } %>
+  <%= hidden_field_tag(:tmdb_id, movie.tmdb_id) %>
+  <%= hidden_field_tag(:list_id, @list.id) if @list.present? && current_user.all_lists.include?(@list) %>
+  <%= hidden_field_tag(:page, params[:page]) %>
+  <%= submit_tag "+ Add", id: "add_tags_button_movies_partial", class: "form-control-submit" %>
+<% end %> <!-- # tag form loop -->
 
 


### PR DESCRIPTION
## Related Issues & PRs
Related to #373

## Problems Solved
When removing a movie from a tag or list on mobile, it is really hard to touch just that small circle-x icon without touching the neighboring item. This PR adds a little bit of right margin to make it a tiny bit easier.

I was originally thinking that we could turn the text + icon into bootstrap badges (#373) to give us a bigger touchable space, but I had forgotten that the list name itself is also a link that goes to that list page. I'm not really sure what I'd like this feature to do, so I went with just adding a little margin right for now to make this problem a tiny bit better.

While mucking around in the html, I cleaned up some rogue closing tags and fixed some blankspacing issues.

## Screenshots
| Before | After |
|-----|------|
| no margin | 5px margin right |
| <img width="469" alt="Screen Shot 2023-10-22 at 11 19 57 AM" src="https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/0c680ccf-114c-44fb-be56-962d298e01ec"> |<img width="479" alt="Screen Shot 2023-10-22 at 11 15 11 AM" src="https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/6fe85452-ccbd-417c-a753-6534cba32830">|

## Things Learned
* We have a lot of conditional logic in the view that could benefit from a refactor. 
* We could consider policies for general user access as well as view logic
* We are on a very old version of bootstrap, fyi
