### PR TITLE
Fix pagination bug on highest-rated movies page

### DIFF
--- a/app/controllers/users/ratings_controller.rb
+++ b/app/controllers/users/ratings_controller.rb
@@ -5,7 +5,7 @@ class Users::RatingsController < ApplicationController
     @ratings = current_user.ratings
       .includes(:movie)
       .where(value: 8..Float::INFINITY)
-      .order(value: :desc)
+      .order(value: :desc, id: :desc)
       .paginate(page: params[:page], per_page: 20)
   end
 end


### PR DESCRIPTION
## Problems Solved
* We're seeing duplicate movies when paginating.
* This is not cool.
* We determined this is because a rating of 8, 9, or 10 is not unique enough, so when the pagination query does an offset, there is no unique edge for this query to find.
* We added the `rating.id` to the `sort` clause to give the query a unique value to anchor to
* This solved the problem for this feature
* It also illuminated why this problem may be happening in other views we have (like list views) which we may solve in future PRs.

