### PR TITLE
Collapse episode info on TV season show page

### DIFF
--- a/app/assets/stylesheets/tmdb.css
+++ b/app/assets/stylesheets/tmdb.css
@@ -48,6 +48,7 @@
   display: flex;
   gap: 100px;
   padding: 10px;
+  border-bottom: 1px solid white;
 }
 
 .episode-image-overview-container {
@@ -65,6 +66,7 @@
 .episode-container img {
   display: block;
   margin-bottom: 10px;
+  max-width: 100%;
 }
 
 ul.common-actor-results li {

--- a/app/views/tmdb/tv_season.html.erb
+++ b/app/views/tmdb/tv_season.html.erb
@@ -65,8 +65,6 @@
             </ul>
           <% end %>
         </div>
-
       </div>
-      <hr>
     </details>
 <% end %>

--- a/app/views/tmdb/tv_season.html.erb
+++ b/app/views/tmdb/tv_season.html.erb
@@ -31,7 +31,7 @@
 
 <% @season.episodes.each do |episode| %>
     <details class='mb-20'>
-      <summary><h3 class='inline-block';><%= episode.episode_number %>. <%= episode.name %></h3></summary>
+      <summary><h3 class='inline-block'><%= episode.episode_number %>. <%= episode.name %></h3></summary>
 
       <div class="episode-container">
         <div class="episode-image-overview-container">

--- a/app/views/tmdb/tv_season.html.erb
+++ b/app/views/tmdb/tv_season.html.erb
@@ -27,39 +27,46 @@
 </div>
 
 <hr>
-
 <h2><%= @season.name %> Episodes</h2>
+
 <% @season.episodes.each do |episode| %>
-    <h2>
-      <%= link_to "#{episode.episode_number}. #{episode.name}",
-        tv_episode_path(
-          show_id: @series.show_id,
-          season_number: @season.season_number,
-          episode_number: episode.episode_number) %>
-    </h2>
-    <div class="episode-container">
-      <div class="episode-image-overview-container">
-        <%= image_tag(
-          TmdbImageService.image_url(file_path: episode.still_path, size: :medium, image_type: :still)
-        ) if episode.still_path.present? %>
-        <%= episode.overview %>
-        <% if episode.air_date.present? %>
-          (Aired on <%= episode.air_date.stamp("01-02-2001") %>)
-        <% end %>
+    <details class='mb-20'>
+      <summary><h3 class='inline-block';><%= episode.episode_number %>. <%= episode.name %></h3></summary>
+
+      <div class="episode-container">
+        <div class="episode-image-overview-container">
+          <%= image_tag(TmdbImageService.image_url(
+              file_path: episode.still_path,
+              size: :large,
+              image_type: :still)) if episode.still_path.present? %>
+
+          <p><%= link_to 'Full Episode Details', tv_episode_path(
+                show_id: @series.show_id,
+                season_number: @season.season_number,
+                episode_number: episode.episode_number) %></p>
+
+          <% if episode.air_date.present? %>
+            <p>Aired: <%= episode.air_date.stamp("01-02-2001") %></p>
+          <% end %>
+
+          <p><%= episode.overview %></p>
+        </div>
+
+        <div class="guest-stars-container">
+          <% if episode.guest_stars.present? %>
+            <h3 class='mb-10'>Guest Stars</h3>
+            <ul>
+              <% episode.guest_stars.each do |guest| %>
+                <li>
+                  <%= link_to "#{guest.name}", actor_search_path(actor: "#{guest.name}") %>
+                  <%= "as #{guest.character_name}" if guest.character_name.present? %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+        </div>
+
       </div>
-      <div class="guest-stars-container">
-        <% if episode.guest_stars.present? %>
-          <h3 class='mb-10'>Guest Stars</h3>
-          <ul>
-            <% episode.guest_stars.each do |guest| %>
-              <li>
-                <%= link_to "#{guest.name}", actor_search_path(actor: "#{guest.name}") %>
-                <%= "as #{guest.character_name}" if guest.character_name.present? %>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
-      </div>
-    </div>
-  <hr>
+      <hr>
+    </details>
 <% end %>


### PR DESCRIPTION
## Problems Solved
* frees up space on TV season show page by tucking content into collapsible html
* uses larger episode image

## Screenshots
| Screen | Before | After |
|----|----|----|
| Desktop | <img width="1414" alt="Screenshot 2024-02-06 at 7 08 16 PM" src="https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/655e1004-798b-40fb-95aa-928c38b6a341"> | <img width="900" alt="Screenshot 2024-02-06 at 6 57 57 PM" src="https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/61b52d70-837a-46d6-b7fb-cc64c5b81ea2">|
| Mobile | <img width="390" alt="Screenshot 2024-02-06 at 7 08 37 PM" src="https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/f599872c-fe77-48de-bd2a-e73ed708cd00"> | <img width="394" alt="Screenshot 2024-02-06 at 7 06 53 PM" src="https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/403db342-73b0-4228-9958-476c0e754399">|


## Things Learned
* unrelated to this PR, but a bunch about getting ruby 3.2.2, openssl and postgres to play nicely together.
* also, chatgpt is my favorite new way to delegate reading long error console output
