### PR TITLE
Collapse season cast

### DIFF
--- a/app/views/tmdb/tv_season.html.erb
+++ b/app/views/tmdb/tv_season.html.erb
@@ -9,24 +9,28 @@
   <p><%= @season.overview %></p>
 </div>
 
+<hr>
+
 <div class='season-cast'>
   <% if @season.cast_members.present? %>
-    <h2><%= @season.name %> Cast</h2>
-     <div class="cast-container">
-      <% @season.cast_members.each do |actor| %>
-        <div class="headshot-container">
-          <%= headshot_for(actor) %>
-          <div class="name-block">
-            <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
-            <p>as <%= truncate(actor.character_name, length: 18, escape: false) %><p>
+    <details class='mb-20'>
+      <summary><h2 class='inline-block'><%= @season.name %> Cast</h2></summary>
+
+      <div class="cast-container">
+        <% @season.cast_members.each do |actor| %>
+          <div class="headshot-container">
+            <%= headshot_for(actor) %>
+            <div class="name-block">
+              <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
+              <p>as <%= truncate(actor.character_name, length: 18, escape: false) %><p>
+            </div>
           </div>
-        </div>
-      <% end %>
-    </div>
+        <% end %>
+      </div>
+    </details>
   <% end %>
 </div>
 
-<hr>
 <h2><%= @season.name %> Episodes</h2>
 
 <% @season.episodes.each do |episode| %>


### PR DESCRIPTION
## Problems Solved
* It is annoying to have to scroll through the season cast when looking for episode info. We know who the season cast is for the most part.
* This PR tucks them into a collapseable section, collapsed by default. 

## Screenshots
| Before: always expanded | After: Collapsed by default |
|------|--------|
|<img width="347" alt="Screenshot 2024-03-19 at 7 27 49 PM" src="https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/6f0a55b4-588c-4beb-bdb5-cbe2c967452e">|<img width="353" alt="Screenshot 2024-03-19 at 7 27 11 PM" src="https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/e7b43c48-55c4-4468-84b7-be5b993d470c">|

