### PR TITLE
Add dropdown to main nav using only css

### DIFF
--- a/app/assets/stylesheets/header.css
+++ b/app/assets/stylesheets/header.css
@@ -1,12 +1,18 @@
+:root {
+  --nav-bar-height: 56px;
+}
+
 .main-nav {
   background: var(--color-secondary);
   color: var(--color-primary);
   overflow: auto;
-  padding: .5rem;
+  padding: 0 .75rem;
+  height: var(--nav-bar-height);
 }
 
 .main-nav ul {
   display: flex;
+  height: inherit;
   justify-content: space-between;
   align-items: center;
 }
@@ -32,7 +38,7 @@
 
 .dropdown-header { width: auto; }
 
-/* hide the inputs/checkmarks and submenu */
+/* Hide the inputs, checkmarks, and submenu */
 .dropdown-header input, ul.dropdown-items {
   display: none;
   position: absolute;
@@ -53,15 +59,9 @@
   cursor: pointer;
 }
 
-/* show the submenu when input is checked */
+/* Show the submenu when input is checked */
 .dropdown-header input:checked~ul.dropdown-items {
   display: block;
   background: var(--color-secondary-darker);
-  margin-top: 1.25rem;
-}
-
-@media (max-width: 700px) {
-  .dropdown-header input:checked~ul.dropdown-items {
-    margin-top: .55rem;
-  }
+  top: var(--nav-bar-height);
 }

--- a/app/assets/stylesheets/header.css
+++ b/app/assets/stylesheets/header.css
@@ -1,6 +1,7 @@
 .main-nav {
   background: var(--color-secondary);
   color: var(--color-primary);
+  overflow: auto;
 }
 
 .main-nav ul {
@@ -28,6 +29,33 @@
   border-radius: 3px;
   padding: 5px;
 }
+
+.menu-item { width: auto; }
+
+/* hide the inputs/checkmarks and submenu */
+.menu-item input, ul.dropdown-items {
+  display: none;
+  position: absolute;
+  width: inherit;
+}
+
+.menu-item input, ul.dropdown-items li:hover {
+  background: hsl(48, 89%, 60%);
+}
+
+.menu-item label {
+  position: relative;
+  display: block;
+  cursor: pointer;
+}
+
+/* show the submenu when input is checked */
+.menu-item input:checked~ul.dropdown-items {
+  display: block;
+  background: hsl(48, 89%, 45%);
+  margin-top: 20px;
+}
+
 
 @media (max-width: 700px) {
   .main-nav form.header-movie-search input, #sign_out_nav_link {

--- a/app/assets/stylesheets/header.css
+++ b/app/assets/stylesheets/header.css
@@ -2,6 +2,7 @@
   background: var(--color-secondary);
   color: var(--color-primary);
   overflow: auto;
+  padding: .5rem;
 }
 
 .main-nav ul {
@@ -12,7 +13,6 @@
 
 .main-nav ul li {
   list-style: none;
-  padding: 10px;
 }
 
 .main-nav a {
@@ -30,39 +30,38 @@
   padding: 5px;
 }
 
-.menu-item { width: auto; }
+.dropdown-header { width: auto; }
 
 /* hide the inputs/checkmarks and submenu */
-.menu-item input, ul.dropdown-items {
+.dropdown-header input, ul.dropdown-items {
   display: none;
   position: absolute;
   width: inherit;
 }
 
-.menu-item input, ul.dropdown-items li:hover {
-  background: hsl(48, 89%, 60%);
+.dropdown-header ul.dropdown-items li {
+  padding: .75rem;
 }
 
-.menu-item label {
+.dropdown-header input, ul.dropdown-items li:hover {
+  background: var(--color-secondary-lighter);
+}
+
+.dropdown-header label {
   position: relative;
   display: block;
   cursor: pointer;
 }
 
 /* show the submenu when input is checked */
-.menu-item input:checked~ul.dropdown-items {
+.dropdown-header input:checked~ul.dropdown-items {
   display: block;
-  background: hsl(48, 89%, 45%);
-  margin-top: 20px;
+  background: var(--color-secondary-darker);
+  margin-top: 1.25rem;
 }
 
-
 @media (max-width: 700px) {
-  .main-nav form.header-movie-search input, #sign_out_nav_link {
-    display: none;
-  }
-
-  .main-nav li:first-of-type {
-    display: none;
+  .dropdown-header input:checked~ul.dropdown-items {
+    margin-top: .55rem;
   }
 }

--- a/app/assets/stylesheets/shared.css
+++ b/app/assets/stylesheets/shared.css
@@ -76,7 +76,6 @@ ul.ui-autocomplete li:hover {
 }
 
 @media (max-width: 768px) {
-  .container {
-    padding: 0 10px;
-  }
+  .container { padding: 0 10px; }
+  .mobile-hidden { display: none; }
 }

--- a/app/assets/stylesheets/variables.css
+++ b/app/assets/stylesheets/variables.css
@@ -1,5 +1,5 @@
 :root {
-  --color-primary: #020d18;
-  --color-secondary: #f1c40f;
+  --color-primary: #020d18; /* hsl(210, 85%, 5%) */
+  --color-secondary: #f1c40f; /* hsl(48, 89%, 50%) */
   --color-links: lightblue;
 }

--- a/app/assets/stylesheets/variables.css
+++ b/app/assets/stylesheets/variables.css
@@ -1,5 +1,11 @@
 :root {
+  --yellow: hsl(48, 89%, 50%); /* #f1c40f */
+  --lighter-yellow: hsl(48, 89%, 60%);
+  --darker-yellow: hsl(48, 89%, 45%);
+
   --color-primary: #020d18; /* hsl(210, 85%, 5%) */
-  --color-secondary: #f1c40f; /* hsl(48, 89%, 50%) */
+  --color-secondary: var(--yellow);
+  --color-secondary-lighter: var(--lighter-yellow);
+  --color-secondary-darker: var(--darker-yellow);
   --color-links: lightblue;
 }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
 <nav class="main-nav">
   <ul>
-    <li class="mobile-hidden"><%= link_to "Home", root_path %></li>
+    <li class="mobile-hidden"><%= link_to 'Home', root_path %></li>
     <% if current_user.present? %>
       <li><%= link_to 'My Movies', movies_path %></li>
       <li><%= link_to 'My Lists', user_lists_path(current_user) %></li>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,10 +1,10 @@
 <nav class="main-nav">
   <ul>
-    <li><%= link_to 'Home', root_path %></li>
+    <li class="mobile-hidden"><%= link_to "Home", root_path %></li>
     <% if current_user.present? %>
       <li><%= link_to 'My Movies', movies_path %></li>
       <li><%= link_to 'My Lists', user_lists_path(current_user) %></li>
-      <div class="menu-item">
+      <li class="dropdown-header">
         <input id="quick-links" type="checkbox" name="quick-links" />
         <label for="quick-links">Quick Links</label>
         <ul class="dropdown-items">
@@ -12,16 +12,16 @@
           <li><%= link_to 'Voyager', '/tmdb/tv_series?show_id=1855' %></li>
           <li><%= link_to 'Resident Alien', '/tmdb/tv_series?show_id=96580' %></li>
         </ul>
-      </div>
+      </li>
       <li><%= link_to 'Search', api_search_path %></li>
     <% end %>
-    <li>
+    <li class="mobile-hidden">
       <%= form_tag '/tmdb/search',
         { class: "header-movie-search", method: :get } do %>
           <%= text_field_tag :movie_title_header, nil, class: "autocomplete-auto-submit", placeholder: "Search for a Movie", data: { autocomplete_source: movie_autocomplete_path } %>
       <% end %>
     </li>
-    <li>
+    <li class="mobile-hidden">
       <%= button_to 'Sign Out', destroy_user_session_path, method: :delete, id: "sign_out_nav_link", class: 'button_to' if current_user.present? %>
     </li>
   </ul>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -4,7 +4,15 @@
     <% if current_user.present? %>
       <li><%= link_to 'My Movies', movies_path %></li>
       <li><%= link_to 'My Lists', user_lists_path(current_user) %></li>
-      <li><%= link_to 'TNG', '/tmdb/tv_series?show_id=655' %></li>
+      <div class="menu-item">
+        <input id="quick-links" type="checkbox" name="quick-links" />
+        <label for="quick-links">Quick Links</label>
+        <ul class="dropdown-items">
+          <li><%= link_to 'TNG', '/tmdb/tv_series?show_id=655' %></li>
+          <li><%= link_to 'Voyager', '/tmdb/tv_series?show_id=1855' %></li>
+          <li><%= link_to 'Resident Alien', '/tmdb/tv_series?show_id=96580' %></li>
+        </ul>
+      </div>
       <li><%= link_to 'Search', api_search_path %></li>
     <% end %>
     <li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
     <%= javascript_importmap_tags %>
   </head>
   <body>
-    <%= render "layouts/environment_banner" %>
+    <%#= render "layouts/environment_banner" %>
     <%= render "layouts/header" %>
     <div class="container">
       <p id="notice"><%= notice %></p>


### PR DESCRIPTION
## Problems Solved
* give us basic css that we can use to make dropdowns in our main navbar without using javascript
* adds "lighter" and "darker" versions of our "secondary" color class
* consolidates (2) media queries to use the same screen width
* surfaces "mobile hidden" css by pulling it into its own class and moving it to the `shared` css
* lets us experiment with the idea of "bookmarked" content on our site for easy access (in this case, i've hardcoded our current TV shows to see if we like it)
* does not componentize this work to use in other places

## Technical considerations
I did end up commenting out the environment banner. It was interfering with the navbar positioning and as per our discussion, the juice wasn't worth the squeeze for our usage.

## Screenshots
![Kapture 2024-04-17 at 10 41 29](https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/dcb47950-caef-4530-a2fd-e1c935b682ac)

## Things Learned
* css is always an interesting journey
* it's handy to use a checkbox input for toggling
* as long as we name our inputs differently, the toggling will work with multiple dropdowns on a page.
* hsl allows us to work around not having access to `lighten($color-secondary, 10%)` in plain css. ex: `hsl(48, 89%, 35%)`
* i keep forgetting that mobile does not have a hover state and end up trying to debug my css. 🤦‍♀️  _hopefully i learned it this time_.
* hardcoding is a great way to pilot an idea 😄 
