### PR TITLE
TV Actor credit improvements

### DIFF
--- a/app/entities/tv_actor_credit.rb
+++ b/app/entities/tv_actor_credit.rb
@@ -18,12 +18,12 @@ class TVActorCredit
   def self.parse_record(record)
     seasons = TVCreditSeason.parse_records(record[:media][:seasons]).presence if record[:media][:seasons].present?
     episodes = TVEpisode.parse_records(record[:media][:episodes]).presence if record[:media][:episodes].present?
-
+    episodes_by_number = episodes.sort_by { |e|e.episode_number } if episodes.present?
     new(
       actor_name: record[:person][:name],
       actor_id: record[:person][:id],
       character: record[:media][:character],
-      episodes: episodes,
+      episodes: episodes_by_number,
       known_for: record[:person][:known_for],
       profile_path: record[:person][:profile_path],
       show_id: record[:media][:id],

--- a/app/views/screenings/index.html.erb
+++ b/app/views/screenings/index.html.erb
@@ -27,4 +27,3 @@
 </table>
 
 <%= link_to '+ New Screening', new_movie_screening_path(@movie), class: 'btn' %>
-<%= link_to "Back to " + @movie.title, movie_path(@movie), class: 'btn' %>

--- a/app/views/tmdb/actor_credit.html.erb
+++ b/app/views/tmdb/actor_credit.html.erb
@@ -1,41 +1,53 @@
 <h1>
-  <%= link_to "#{@credit.actor_name}", actor_more_path(actor_id: @credit.actor_id) %> <%= "as #{@credit.character}" if @credit.character.present? %> on <%= link_to "#{@credit.show_name}", tv_series_path(show_id: @credit.show_id) %>
+  Episodes with <%= link_to "#{@credit.actor_name}", actor_more_path(actor_id: @credit.actor_id) %>
+  <%= "as #{@credit.character}" if @credit.character.present? %>
+  on <%= link_to "#{@credit.show_name}", tv_series_path(show_id: @credit.show_id) %>
 </h1>
-<%= link_to "Back to Actor Profile", actor_more_path(actor_id: @credit.actor_id), class: 'btn' %>
+<%= link_to "Actor Profile", actor_more_path(actor_id: @credit.actor_id), class: 'btn' %>
 
 <% if @credit.episodes.present? %>
-  <h2>Episodes with <%= @credit.actor_name %></h2>
-  <table>
-    <tbody>
-      <% @credit.episodes.each do |episode| %>
-        <tr>
-          <td>
-            <h2>Air date: <%= episode.air_date %></h2>
-            <p><%= "Overview: #{episode.overview}" if episode.overview.present? %></p>
-            <p><%= link_to "Season: #{episode.season_number}", tv_season_path(season_number: episode.season_number, show_id: @credit.show_id, actor_id: @credit.actor_id) %>, Episode: <%= episode.episode_number %></p>
-            <% if episode.still_path.present? %>
-              <p>
-                <%= image_tag(TmdbImageService.image_url(file_path: episode.still_path, size: :medium, image_type: :still)) %>
-              </p>
+  <% @credit.episodes.group_by {|c| c.season_number}.each do |season| %>
+    <details open>
+      <summary class='mt-10'><h2 class='inline-block'>Season <%= season.first %></h2></summary>
+
+      <% season.last.each do |episode| %>
+        <h3 class='mt-10'>
+          <%= episode.episode_number %>.
+          <%= link_to episode.name, tv_episode_path(
+                    show_id: @credit.show_id,
+                    season_number: episode.season_number,
+                    episode_number: episode.episode_number) %>
+        </h3>
+        <div class="episode-container">
+          <div class="episode-image-overview-container">
+            <%= image_tag(TmdbImageService.image_url(
+                file_path: episode.still_path,
+                size: :large,
+                image_type: :still)) if episode.still_path.present? %>
+
+            <% if episode.air_date.present? %>
+              <p>Aired: <%= episode.air_date.stamp("01-02-2001") %></p>
             <% end %>
-          </td>
-        </tr>
+
+            <p><%= episode.overview %></p>
+          </div>
+
+          <div class="guest-stars-container">
+            <% if episode.guest_stars.present? %>
+              <h3 class='mb-10'>Guest Stars</h3>
+              <ul>
+                <% episode.guest_stars.each do |guest| %>
+                  <li>
+                    <%= link_to "#{guest.name}", actor_search_path(actor: "#{guest.name}") %>
+                    <%= "as #{guest.character_name}" if guest.character_name.present? %>
+                  </li>
+                <% end %>
+              </ul>
+            <% end %>
+          </div>
+        </div>
       <% end %>
-    </tbody>
-  </table>
+    </details>
+  <% end %>
 <% end %>
 
-<% if @credit.seasons.present? %>
-<h2>Seasons with <%= @credit.actor_name %></h2>
-<table>
-  <% @credit.seasons.each do |season| %>
-  <tr>
-    <td>
-      <%= image_tag(TmdbImageService.image_url(file_path: season.poster_path, size: :xsmall, image_type: :poster)) if season.poster_path.present? %>
-    </td>
-    <td><%= link_to "Season: #{season_number_display(season.season_number)}", tv_season_path(season_number: season.season_number, show_id: @credit.show_id, actor_id: @credit.actor_id) %></td>
-    <td>Air date: <%= season.air_date %></td>
-  </tr>
-  <% end %>
-</table>
-<% end %>

--- a/app/views/tmdb/tv_season.html.erb
+++ b/app/views/tmdb/tv_season.html.erb
@@ -64,6 +64,8 @@
                 <li>
                   <%= link_to "#{guest.name}", actor_search_path(actor: "#{guest.name}") %>
                   <%= "as #{guest.character_name}" if guest.character_name.present? %>
+                  | <%= link_to "Episodes", actor_credit_path(actor_id: guest.actor_id, credit_id: guest.credit_id,
+    show_name: "#{@series.show_name}"), id: "appearance_details_#{@series.show_name.downcase}" %>
                 </li>
               <% end %>
             </ul>


### PR DESCRIPTION
## Problems Solved
* adds easy link to the episode breakdown for guest stars as that character from the season page
* redesigns the guest star's episode breakdown for better mobile use and consistency with the season page
* removes unnecessary "back" link on the screenings index

## Screenshots

| Page | Before | After |
|---|---|---|
| Episode Guest Stars | <img width="354" alt="Screenshot 2024-05-26 at 1 59 17 PM" src="https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/119036e0-ea11-4408-84b7-64eecb2fb304"> | <img width="349" alt="Screenshot 2024-05-26 at 1 47 04 PM" src="https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/8b309dcd-774b-469c-bb2f-43064417d5e0"> |
| Episode breakdown | <img width="356" alt="Screenshot 2024-05-26 at 1 58 53 PM" src="https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/60ee7ea7-b62f-400b-923f-a118e12d0e7d"> | <img width="353" alt="Screenshot 2024-05-26 at 2 09 11 PM" src="https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/64107225-07ce-4e93-a799-21b950ab501d"> |

## Things Learned
* I wanted to put the actor headshot on the episode breakdown page, but we don't have access to it in that object at the time.
