### PR TITLE
Link to actor bio from tv series page & fix image size

### DIFF
--- a/app/views/tmdb/tv_season.html.erb
+++ b/app/views/tmdb/tv_season.html.erb
@@ -62,7 +62,7 @@
             <ul>
               <% episode.guest_stars.each do |guest| %>
                 <li>
-                  <%= link_to "#{guest.name}", actor_search_path(actor: "#{guest.name}") %>
+                  <%= link_to guest.name, actor_more_path(actor_id: guest.actor_id) %>
                   <%= "as #{guest.character_name}" if guest.character_name.present? %>
                   | <%= link_to "Episodes", actor_credit_path(actor_id: guest.actor_id, credit_id: guest.credit_id,
     show_name: "#{@series.show_name}"), id: "appearance_details_#{@series.show_name.downcase}" %>


### PR DESCRIPTION
## Problems Solved
* links directly to the actor bio page from the guest star credit instead of going to the movies search page
* fixes the episode image on the episode page

## Screenshots
| Before | After | 
|---|----|
| <img width="351" alt="Screenshot 2024-05-26 at 2 26 27 PM" src="https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/1205e859-f05a-431c-933c-aca2857069c5"> | <img width="354" alt="Screenshot 2024-05-26 at 2 25 34 PM" src="https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/3345cde9-6d79-4d99-9fd3-503735ed55e8"> |

