### PR TITLE
Fix tv episode image on mobile

### DIFF
--- a/app/assets/stylesheets/cast.css
+++ b/app/assets/stylesheets/cast.css
@@ -35,15 +35,6 @@
   font-size: 1.2rem;
 }
 
-.poster-overview-container {
-  display: flex;
-  gap: 10px;
-}
-
-.poster-overview-container img {
-  max-height: 278px;
-}
-
 .episode-container {
   display: flex;
   gap: 100px;

--- a/app/views/tmdb/tv_episode.html.erb
+++ b/app/views/tmdb/tv_episode.html.erb
@@ -5,17 +5,11 @@
 </h2>
 
 <h1><%= @episode.name %></h1>
-<div class='poster-overview-container'>
-  <%= image_tag(
-    TmdbImageService.image_url(file_path: @episode.still_path, size: :medium, image_type: :still)
-  ) if @episode.still_path.present? %>
-  <p>
-    <%= @episode.overview %>
-    <% if @episode.air_date.present? %>
-      Aired on <%= @episode.air_date.stamp("01-02-2001") %>
-    <% end %>
-  </p>
-</div>
+<%= image_tag(TmdbImageService.image_url(file_path: @episode.still_path, size: :large, image_type: :still)) if @episode.still_path.present? %>
+<% if @episode.air_date.present? %>
+  <p>Aired on <%= @episode.air_date.stamp("01-02-2001") %></p>
+<% end %>
+<p><%= @episode.overview %></p>
 
 <h2>Cast</h2>
 <div class="cast-container">


### PR DESCRIPTION
## Problems Solved
This PR fixes the episode image on the episode page. It had ended up being both squashed and stretched, so I just used a larger image from the API and gave it its own line. This is also more consistent with way we're handing images on other tv pages.

## Screenshots
| Before | After | 
|---|----|
| <img width="351" alt="Screenshot 2024-05-26 at 2 26 27 PM" src="https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/1205e859-f05a-431c-933c-aca2857069c5"> | <img width="354" alt="Screenshot 2024-05-26 at 2 25 34 PM" src="https://github.com/mikevallano/tmdb-moviequeue/assets/8680712/3345cde9-6d79-4d99-9fd3-503735ed55e8"> |

