### PR TITLE
Link to actor bio or episode page from TV pages

### DIFF
--- a/app/views/shared/_tv_series_profile_content.html.erb
+++ b/app/views/shared/_tv_series_profile_content.html.erb
@@ -38,7 +38,7 @@
           <div class="headshot-container">
             <%= headshot_for(actor) %>
             <div class="name-block">
-              <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}")) %></p>
+              <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_more_path(actor_id: actor.actor_id) %></p>
               <p>as <%= truncate(actor.character_name, length: 18, escape: false) %></p>
             </div>
           </div>

--- a/app/views/tmdb/tv_episode.html.erb
+++ b/app/views/tmdb/tv_episode.html.erb
@@ -13,21 +13,25 @@
 
 <h2>Cast</h2>
 <div class="cast-container">
-<% @season.cast_members.each do |actor| %>
-  <div class="headshot-container">
-  <%= headshot_for(actor) %>
-    <div class="name-block">
-      <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
-      <p>as <%= truncate(actor.character_name, length: 18, escape: false) %><p>
+  <% @season.cast_members.each do |actor| %>
+    <div class="headshot-container">
+    <%= headshot_for(actor) %>
+      <div class="name-block">
+        <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_more_path(actor_id: actor.actor_id)  %></p>
+        <p>as <%= truncate(actor.character_name, length: 18, escape: false) %><p>
+      </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>
+
 <% if @episode.guest_stars.present? %>
+<h2>Guests</h2>
+<div class="cast-container">
   <% @episode.guest_stars.each do |actor| %>
     <div class="headshot-container">
     <%= headshot_for(actor) %>
       <div class="name-block">
-        <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
+        <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_credit_path(actor_id: actor.actor_id, credit_id: actor.credit_id, show_name: "#{@series.show_name}")  %></p>
         <p>as <%= truncate(actor.character_name, length: 18, escape: false) %><p>
       </div>
     </div>

--- a/app/views/tmdb/tv_season.html.erb
+++ b/app/views/tmdb/tv_season.html.erb
@@ -21,7 +21,7 @@
           <div class="headshot-container">
             <%= headshot_for(actor) %>
             <div class="name-block">
-              <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
+              <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_more_path(actor_id: actor.actor_id)  %></p>
               <p>as <%= truncate(actor.character_name, length: 18, escape: false) %><p>
             </div>
           </div>


### PR DESCRIPTION
## Problems Solved
When looking at actor credits from TV shows, we didn't like needing to go through the actor's movies list in order to get to the bio. We fixed this for the movie actors, but not the TV actors. This PR fixes it for the TV actors.

1. Links to main cast member's bio page instead of movies search page on the:
    * Series `:show` page
    * Season `:show` page
    * Episode `:show` page

2. Links to guest star's episodes listings for this show on the Episode `:show` page
    * I would like to have linked consistently to the episodes listings page from the Episode `:show` page, but weirdly, there isn't any data for the Cast actors. 
    * I chose to _not_ link to the Guest actors' bio pages because I usually want to know how many episodes of this series the person has been in (kind of like Jeffrey Combs).
4. Separates Cast actors from Guest actors because the links are different on the Episode `:show` page

