### PR TITLE
Convert hard coded "quick links" to db-backed resource

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 source 'https://rubygems.org'
 
-ruby '3.2.2'
-gem 'puma', '6.4.2'
+ruby File.read(".ruby-version").strip
+
 gem 'rails', '~> 7.1.3'
+gem 'puma', '6.4.2'
 gem 'pg', '~> 1.1'
 gem 'sass-rails'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    ffaker (2.23.0)
+    ffaker (2.21.0)
     ffi (1.16.3)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    ffaker (2.21.0)
+    ffaker (2.23.0)
     ffi (1.16.3)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -C config/puma.rb
+release: rails db:migrate

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@
 
 * There are no special rake tasks or seeds.
 
-* Simply running `$ rsepc` will run the test suite, which uses Selenium, and therefore launches Firefox.
+* Simply running `$ rspec` will run the test suite, which uses Selenium, and therefore launches Firefox.
 
 * There are no background jobs.
 
-* The data is gathered from the awesome API available from TMDB: <https://www.themoviedb.org/documentation/api>, which is managed in the tmdb_controller and the tmdb_handler module in the lib directory. You will need to sign up at TMDB and get your own API key, which is referenced as an environment variable throughout this project.
+* The data is gathered from the awesome API available from TMDB: <https://www.themoviedb.org/documentation/api>, which is managed in the tmdb_controller and the tmdb_handler module in the lib directory. You will need to sign up at TMDB and get your own API key, which is referenced as an environment variable throughout this project. You can do whatever method you prefer for storing API keys. An easy way to add it to your local environment is running this in your console `export tmdb_api_key=YOU-API-KEY`.
 
 ## Creators and Maintainers:
-This site was built to solve our own problem of movie management, which started as a crappy Google sheet, then evolved to a Rails app.  The other puropse was to build a Rails app that showcased our Rails skills. "We" are [Mike](https://github.com/mikevallano?tab=repositories) (back end) and [Anne](https://github.com/lortza?tab=repositories) (front end).
+This site was built to solve our own problem of movie management, which started as a crappy Google sheet, then evolved to a Rails app.  The other purpose was to build a Rails app that showcased our Rails skills. "We" are [Mike](https://github.com/mikevallano?tab=repositories) (back end) and [Anne](https://github.com/lortza?tab=repositories) (front end).
 
 ## Wiki
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,16 @@
 
 * No special server info. It's using Puma, and `$ rails s` will do it.
 
-* There are no special rake tasks or seeds.
+* There are no special rake tasks. Just seeds.
 
 * Simply running `$ rspec` will run the test suite, which uses Selenium, and therefore launches Firefox.
 
 * There are no background jobs.
 
-* The data is gathered from the awesome API available from TMDB: <https://www.themoviedb.org/documentation/api>, which is managed in the tmdb_controller and the tmdb_handler module in the lib directory. You will need to sign up at TMDB and get your own API key, which is referenced as an environment variable throughout this project. You can do whatever method you prefer for storing API keys. An easy way to add it to your local environment is running this in your console `export tmdb_api_key=YOU-API-KEY`.
+* The data is gathered from the awesome API available from TMDB: <https://www.themoviedb.org/documentation/api>, which is managed in the tmdb_controller and the tmdb_handler module in the lib directory. You will need to sign up at TMDB and get your own API key, which is referenced as an environment variable throughout this project. You can do whatever method you prefer for storing API keys. An easy way to add it to your local environment is running this in your console `export tmdb_api_key=YOUR-API-KEY`.
 
 ## Creators and Maintainers:
-This site was built to solve our own problem of movie management, which started as a crappy Google sheet, then evolved to a Rails app.  The other purpose was to build a Rails app that showcased our Rails skills. "We" are [Mike](https://github.com/mikevallano?tab=repositories) (back end) and [Anne](https://github.com/lortza?tab=repositories) (front end).
+This site was built to solve our own problem of movie management, which started as a crappy Google sheet, then evolved to a Rails app. The other purpose was to build a Rails app that showcased our Rails skills. "We" are [Mike](https://github.com/mikevallano?tab=repositories) and [Anne](https://github.com/lortza?tab=repositories).
 
 ## Wiki
-
 For more details about functionality/app setup, check out the [wiki](https://github.com/mikevallano/tmdb-moviequeue/wiki/Wiki-Home).

--- a/app/assets/stylesheets/forms.css
+++ b/app/assets/stylesheets/forms.css
@@ -31,6 +31,13 @@ form select {
   background: none;
   border: none;
   color: var(--color-links);
+  padding: 0;
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+.screenings-providers-container span.material-symbols-outlined {
+  font-size: 1rem;
 }
 
 form.form input, textarea, select {

--- a/app/assets/stylesheets/header.css
+++ b/app/assets/stylesheets/header.css
@@ -49,6 +49,10 @@
   padding: .75rem;
 }
 
+.dropdown-header .dropdown-items hr {
+  border-color: var(--color-secondary);
+}
+
 .dropdown-header input, ul.dropdown-items li:hover {
   background: var(--color-secondary-lighter);
 }

--- a/app/controllers/tv_series_viewings_controller.rb
+++ b/app/controllers/tv_series_viewings_controller.rb
@@ -1,0 +1,7 @@
+class TVSeriesViewingsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @viewings = current_user.tv_series_viewings
+  end
+end

--- a/app/controllers/tv_series_viewings_controller.rb
+++ b/app/controllers/tv_series_viewings_controller.rb
@@ -6,56 +6,33 @@ class TVSeriesViewingsController < ApplicationController
   end
 
   def create
-    @viewing = current_user.tv_series_viewings.create(
+    @viewing = current_user.tv_series_viewings.new(
       title: params[:title],
       show_id: params[:show_id],
       url: tv_series_path(show_id: params[:show_id]),
       started_at: Time.current
     )
 
-    # respond_to do |format|
-    #   if viewing.save
-    #     format.turbo_stream {}
-    #     format.html { redirect_to tv_series_path, notice: 'Added to Currently Watching List.' }
-    #   end
-    # end
+    respond_to do |format|
+      if @viewing.save
+        format.turbo_stream {}
+        format.html { redirect_to tv_series_path(show_id: params[:show_id]), notice: 'Added to Currently Watching List.' }
+      else
+        format.html { redirect_to tv_series_path(show_id: params[:show_id]), error: 'Could not add to Currently Watching List.' }
+      end
+    end
   end
 
   def update
     @viewing = current_user.tv_series_viewings.active.find_by(show_id: params[:show_id])
-    binding.pry
-    @viewing.update(ended_at: Time.current)
-  end
 
-  # def create
-  #   @screening = current_user.screenings.new(screening_params)
-  #   @screening.movie_id = @movie.id
-
-  #   respond_to do |format|
-  #     if @screening.save
-  #       format.turbo_stream {}
-  #       format.html { redirect_to movie_screenings_path(@movie), notice: 'Screening was successfully created.' }
-  #       format.json { render :show, status: :created, location: @screening }
-  #     else
-  #       format.html { render :new }
-  #       format.json { render json: @screening.errors, status: :unprocessable_entity }
-  #     end
-  #   end
-  # end
-
-  # def update
-  #   respond_to do |format|
-  #     if @screening.update(screening_params)
-  #       format.html { redirect_to movie_screenings_path(@movie), notice: 'Screening was successfully updated.' }
-  #       format.json { render :show, status: :ok, location: @screening }
-  #     else
-  #       format.html { render :edit }
-  #       format.json { render json: @screening.errors, status: :unprocessable_entity }
-  #     end
-  #   end
-  # end
-  
-  def tv_series_viewings_params
-    binding.pry
+    respond_to do |format|
+      if @viewing.update(ended_at: Time.current)
+        format.turbo_stream {}
+        format.html { redirect_to tv_series_path(show_id: params[:show_id]), notice: 'Removed from Currently Watching List.' }
+      else
+        format.html { redirect_to tv_series_path(show_id: params[:show_id]), error: 'Could not remove from Currently Watching List.' }
+      end
+    end
   end
 end

--- a/app/controllers/tv_series_viewings_controller.rb
+++ b/app/controllers/tv_series_viewings_controller.rb
@@ -4,4 +4,58 @@ class TVSeriesViewingsController < ApplicationController
   def index
     @viewings = current_user.tv_series_viewings
   end
+
+  def create
+    @viewing = current_user.tv_series_viewings.create(
+      title: params[:title],
+      show_id: params[:show_id],
+      url: tv_series_path(show_id: params[:show_id]),
+      started_at: Time.current
+    )
+
+    # respond_to do |format|
+    #   if viewing.save
+    #     format.turbo_stream {}
+    #     format.html { redirect_to tv_series_path, notice: 'Added to Currently Watching List.' }
+    #   end
+    # end
+  end
+
+  def update
+    @viewing = current_user.tv_series_viewings.active.find_by(show_id: params[:show_id])
+    binding.pry
+    @viewing.update(ended_at: Time.current)
+  end
+
+  # def create
+  #   @screening = current_user.screenings.new(screening_params)
+  #   @screening.movie_id = @movie.id
+
+  #   respond_to do |format|
+  #     if @screening.save
+  #       format.turbo_stream {}
+  #       format.html { redirect_to movie_screenings_path(@movie), notice: 'Screening was successfully created.' }
+  #       format.json { render :show, status: :created, location: @screening }
+  #     else
+  #       format.html { render :new }
+  #       format.json { render json: @screening.errors, status: :unprocessable_entity }
+  #     end
+  #   end
+  # end
+
+  # def update
+  #   respond_to do |format|
+  #     if @screening.update(screening_params)
+  #       format.html { redirect_to movie_screenings_path(@movie), notice: 'Screening was successfully updated.' }
+  #       format.json { render :show, status: :ok, location: @screening }
+  #     else
+  #       format.html { render :edit }
+  #       format.json { render json: @screening.errors, status: :unprocessable_entity }
+  #     end
+  #   end
+  # end
+  
+  def tv_series_viewings_params
+    binding.pry
+  end
 end

--- a/app/models/tv_series_viewing.rb
+++ b/app/models/tv_series_viewing.rb
@@ -1,0 +1,53 @@
+# A TVSeriesViewing persists a log of how many times a person has engaged with watching a TV Series. It does not 
+# track episode viewings, but rather the larger arc of when a user started the epic of watching a series and when
+# they stopped. For example, a user may have watched "Parks and Recreation" as an entire series several times. 
+# A user may have only watched "The Office" once. Therefore it is possible for a TV Series to have multiple 
+# entries with different start and end dates. 
+
+class TVSeriesViewing < ApplicationRecord
+  belongs_to :user
+  # TODO: add uniqueness to user_id, show_id...?
+  
+  # validates :username, presence: true, uniqueness: true
+
+  validates_presence_of :title, :url, :show_id, :started_at
+  
+  MAX_ACTIVE_RECORDS = 8
+  
+  # before_create: :check_for_active_viewing
+  def check_for_active_viewing
+    # maybe this is just a find-or-create-by
+  end
+  
+
+  def self.limit_reached?
+    active.size >= MAX_ACTIVE_RECORDS
+  end
+
+  def self.active
+    where(ended_at: nil)
+  end
+  
+  def active?
+    ended_at.nil?
+  end
+
+
+  # self.data = [
+  #   { user_id: 1, title: 'Brooklyn Nine Nine', url: '/tmdb/tv_series?show_id=48891', show_id: '48891', started_at: '2024-12-01'.to_date, ended_at: nil },
+  #   { user_id: 1, title: 'DS9', url: '/tmdb/tv_series?show_id=580', show_id: '580', started_at: '2024-12-01'.to_date, ended_at: nil },
+  #   { user_id: 1, title: 'Enterprise', url: '/tmdb/tv_series?show_id=314', show_id: '314', started_at: '2024-12-01'.to_date, ended_at: nil },
+  #   { user_id: 1, title: 'Monk', url: '/tmdb/tv_series?show_id=1695', show_id: '1695', started_at: '2024-12-01'.to_date, ended_at: nil },
+  #   { user_id: 1, title: 'Parks & Rec', url: '/tmdb/tv_series?show_id=8592', show_id: '8592', started_at: '2024-12-01'.to_date, ended_at: nil },
+  #   { user_id: 1, title: 'Resident Alien', url: '/tmdb/tv_series?show_id=96580', show_id: '96580', started_at: '2024-03-05'.to_date, ended_at: '2024-05-15'.to_date  },
+  #   { user_id: 1, title: 'The Good Place', url: '/tmdb/tv_series?show_id=66573', show_id: '66573', started_at: '2024-10-02'.to_date, ended_at: '2024-10-12'.to_date },
+  #   { user_id: 1, title: 'AP Bio - Season 1', url: 'tmdb/tv_season?season_number=1&show_id=71737&title=A.P.+Bio', show_id: '71737', started_at: '2024-12-01'.to_date, ended_at: nil },
+  # ]
+end
+
+
+
+
+
+
+

--- a/app/models/tv_series_viewing.rb
+++ b/app/models/tv_series_viewing.rb
@@ -12,7 +12,7 @@ class TVSeriesViewing < ApplicationRecord
   validates :ended_at, uniqueness: { scope: [:user_id, :show_id] }
   validates_presence_of :title, :url, :show_id, :started_at
   
-  scope :active, -> {where(ended_at: nil) }
+  scope :active, -> { where(ended_at: nil) }
   
   def active?
     ended_at.nil?

--- a/app/models/tv_series_viewing.rb
+++ b/app/models/tv_series_viewing.rb
@@ -7,6 +7,8 @@
 class TVSeriesViewing < ApplicationRecord
   belongs_to :user
   # TODO: add uniqueness to user_id, show_id...?
+  # validates :show_id, uniqueness: {scope: :user_id, case_sensitive: false}
+  # 
   
   # validates :username, presence: true, uniqueness: true
 

--- a/app/models/tv_series_viewing.rb
+++ b/app/models/tv_series_viewing.rb
@@ -1,55 +1,20 @@
-# A TVSeriesViewing persists a log of how many times a person has engaged with watching a TV Series. It does not 
-# track episode viewings, but rather the larger arc of when a user started the epic of watching a series and when
-# they stopped. For example, a user may have watched "Parks and Recreation" as an entire series several times. 
-# A user may have only watched "The Office" once. Therefore it is possible for a TV Series to have multiple 
-# entries with different start and end dates. 
+# A TVSeriesViewing persists a log of how many times a person has engaged with watching 
+# a TV Series. It does not track *episode* viewings, but rather the larger arc of when 
+# a user started the epic of watching a series and when they stopped. For example, a 
+# user may have watched "Parks and Recreation" as an entire series several times. 
+# A user may have only watched "The Office" once. Therefore it is possible for a 
+# TV Series to have multiple entries with different start and end dates. 
 
 class TVSeriesViewing < ApplicationRecord
   belongs_to :user
-  # TODO: add uniqueness to user_id, show_id...?
-  # validates :show_id, uniqueness: {scope: :user_id, case_sensitive: false}
-  # 
-  
-  # validates :username, presence: true, uniqueness: true
 
+  # We don't want a user to have duplicate active viewings for a series
+  validates :ended_at, uniqueness: { scope: [:user_id, :show_id] }
   validates_presence_of :title, :url, :show_id, :started_at
   
-  MAX_ACTIVE_RECORDS = 8
-  
-  # before_create: :check_for_active_viewing
-  def check_for_active_viewing
-    # maybe this is just a find-or-create-by
-  end
-  
-
-  def self.limit_reached?
-    active.size >= MAX_ACTIVE_RECORDS
-  end
-
-  def self.active
-    where(ended_at: nil)
-  end
+  scope :active, -> {where(ended_at: nil) }
   
   def active?
     ended_at.nil?
   end
-
-
-  # self.data = [
-  #   { user_id: 1, title: 'Brooklyn Nine Nine', url: '/tmdb/tv_series?show_id=48891', show_id: '48891', started_at: '2024-12-01'.to_date, ended_at: nil },
-  #   { user_id: 1, title: 'DS9', url: '/tmdb/tv_series?show_id=580', show_id: '580', started_at: '2024-12-01'.to_date, ended_at: nil },
-  #   { user_id: 1, title: 'Enterprise', url: '/tmdb/tv_series?show_id=314', show_id: '314', started_at: '2024-12-01'.to_date, ended_at: nil },
-  #   { user_id: 1, title: 'Monk', url: '/tmdb/tv_series?show_id=1695', show_id: '1695', started_at: '2024-12-01'.to_date, ended_at: nil },
-  #   { user_id: 1, title: 'Parks & Rec', url: '/tmdb/tv_series?show_id=8592', show_id: '8592', started_at: '2024-12-01'.to_date, ended_at: nil },
-  #   { user_id: 1, title: 'Resident Alien', url: '/tmdb/tv_series?show_id=96580', show_id: '96580', started_at: '2024-03-05'.to_date, ended_at: '2024-05-15'.to_date  },
-  #   { user_id: 1, title: 'The Good Place', url: '/tmdb/tv_series?show_id=66573', show_id: '66573', started_at: '2024-10-02'.to_date, ended_at: '2024-10-12'.to_date },
-  #   { user_id: 1, title: 'AP Bio - Season 1', url: 'tmdb/tv_season?season_number=1&show_id=71737&title=A.P.+Bio', show_id: '71737', started_at: '2024-12-01'.to_date, ended_at: nil },
-  # ]
 end
-
-
-
-
-
-
-

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,8 @@ class User < ApplicationRecord
   has_many :watched_movies, through: :screenings,
   source: :movie
 
+  has_many :tv_series_viewings
+
   def all_lists
     list_ids = lists.pluck(:id)
     member_list_ids = member_lists.pluck(:id)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -8,9 +8,9 @@
           <input id="my-shows" type="checkbox" name="my-shows" />
           <label for="my-shows">My Shows</label>
           <ul class="dropdown-items">
-            <li>WIP Viewing History</li>
+            <li><%= link_to 'See Viewing History', tv_series_viewings_path %></li>
             <hr>
-            <% current_user.tv_series_viewings.each do |show| %>
+            <% current_user.tv_series_viewings.active.each do |show| %>
               <li><%= link_to show.title, show.url %></li>
             <% end %>
           </ul>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -14,7 +14,7 @@
     </li>
 
     <% if current_user.present? %>
-      <li class="dropdown-header">
+      <li class="dropdown-header mobile-hidden">
         <input id="quick-links" type="checkbox" name="quick-links" />
         <label for="quick-links"><%= current_user.username %></label>
         <ul class="dropdown-items">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,19 +3,7 @@
     <li class="mobile-hidden"><%= link_to 'Home', root_path %></li>
     <% if current_user.present? %>
       <li><%= link_to 'My Movies', user_lists_path(current_user) %></li>
-      <% if current_user.tv_series_viewings.any? %>
-        <li class="dropdown-header">
-          <input id="my-shows" type="checkbox" name="my-shows" />
-          <label for="my-shows">My Shows</label>
-          <ul class="dropdown-items">
-            <li><%= link_to 'See Viewing History', tv_series_viewings_path %></li>
-            <hr>
-            <% current_user.tv_series_viewings.active.each do |show| %>
-              <li><%= link_to show.title, show.url %></li>
-            <% end %>
-          </ul>
-        </li>
-      <% end %>
+      <%= render 'tv_series_viewings/navbar_dropdown' %>
       <li><%= link_to 'Search', api_search_path %></li>
     <% end %>
     <li class="mobile-hidden">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -2,21 +2,20 @@
   <ul>
     <li class="mobile-hidden"><%= link_to 'Home', root_path %></li>
     <% if current_user.present? %>
-      <li><%= link_to 'My Movies', movies_path %></li>
-      <li><%= link_to 'My Lists', user_lists_path(current_user) %></li>
-      <li class="dropdown-header">
-        <input id="quick-links" type="checkbox" name="quick-links" />
-        <label for="quick-links">Quick Links</label>
-        <ul class="dropdown-items">
-          <li><%= link_to 'Brooklyn Nine Nine', '/tmdb/tv_series?show_id=48891' %></li>
-          <li><%= link_to 'DS9', '/tmdb/tv_series?show_id=580' %></li>
-          <li><%= link_to 'Enterprise', '/tmdb/tv_series?show_id=314' %></li>
-          <li><%= link_to 'Monk', '/tmdb/tv_series?show_id=1695' %></li>
-          <li><%= link_to 'Parks & Rec', '/tmdb/tv_series?show_id=8592' %></li>
-          <li><%= link_to 'Resident Alien', '/tmdb/tv_series?show_id=96580' %></li>
-          <li><%= link_to 'The Good Place', '/tmdb/tv_series?show_id=66573' %></li>
-        </ul>
-      </li>
+      <li><%= link_to 'My Movies', user_lists_path(current_user) %></li>
+      <% if current_user.tv_series_viewings.any? %>
+        <li class="dropdown-header">
+          <input id="my-shows" type="checkbox" name="my-shows" />
+          <label for="my-shows">My Shows</label>
+          <ul class="dropdown-items">
+            <li>WIP Viewing History</li>
+            <hr>
+            <% current_user.tv_series_viewings.each do |show| %>
+              <li><%= link_to show.title, show.url %></li>
+            <% end %>
+          </ul>
+        </li>
+      <% end %>
       <li><%= link_to 'Search', api_search_path %></li>
     <% end %>
     <li class="mobile-hidden">
@@ -25,8 +24,16 @@
           <%= text_field_tag :movie_title_header, nil, class: "autocomplete-auto-submit", placeholder: "Search for a Movie", data: { autocomplete_source: movie_autocomplete_path } %>
       <% end %>
     </li>
-    <li class="mobile-hidden">
-      <%= button_to 'Sign Out', destroy_user_session_path, method: :delete, id: "sign_out_nav_link", class: 'button_to' if current_user.present? %>
-    </li>
+
+    <% if current_user.present? %>
+      <li class="dropdown-header">
+        <input id="quick-links" type="checkbox" name="quick-links" />
+        <label for="quick-links"><%= current_user.username %></label>
+        <ul class="dropdown-items">
+          <li><%= link_to 'Settings', user_path(current_user) %></li>
+          <li><%= button_to 'Sign Out', destroy_user_session_path, method: :delete, id: "sign_out_nav_link", class: 'button_to' %></li>
+        </ul>
+      </li>
+    <% end %>
   </ul>
 </nav>

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -5,6 +5,7 @@
 <%= link_to 'New List'.html_safe, new_user_list_path(current_user), class: 'btn' %></p>
 
 <div class="lists-container mt-10">
+  <div class="list"><%= link_to 'My Movies', movies_path %></div>
   <div class="list"><%= link_to 'My Top-Rated Movies', user_ratings_path(current_user) %></div>
   <% @lists.order(name: :asc).each do |list| %>
     <div class="list">

--- a/app/views/movies/_movie_deets.html.erb
+++ b/app/views/movies/_movie_deets.html.erb
@@ -2,7 +2,7 @@
     <div class="watch-info">
       <div class="image-screenings-providers-container">
         <%= link_to image_for(movie), link_to_movie(movie), data: { turbo: false } %>
-        <div class="screenings-providiers-container">
+        <div class="screenings-providers-container">
           <%= render 'movies/screenings', movie: movie %>
           <%= render "shared/streaming_service_providers", streaming_service_providers: movie.streaming_service_providers %>
         </div>

--- a/app/views/shared/_tv_series_profile_content.html.erb
+++ b/app/views/shared/_tv_series_profile_content.html.erb
@@ -8,7 +8,7 @@
         id: "movie_show_link_movie_partial"
       ) if media.poster_path.present? %>
 
-      <div class="screenings-providiers-container">
+      <div class="screenings-providers-container">
         <%= render "shared/streaming_service_providers", streaming_service_providers: media.streaming_service_providers %>
       </div>
     </div>

--- a/app/views/shared/_tv_series_profile_content.html.erb
+++ b/app/views/shared/_tv_series_profile_content.html.erb
@@ -9,6 +9,7 @@
       ) if media.poster_path.present? %>
 
       <div class="screenings-providers-container">
+        <%= render "tv_series_viewings/buttons_toggle", show_id: media.show_id, title: media.show_name %>
         <%= render "shared/streaming_service_providers", streaming_service_providers: media.streaming_service_providers %>
       </div>
     </div>

--- a/app/views/tv_series_viewings/_buttons_toggle.html.erb
+++ b/app/views/tv_series_viewings/_buttons_toggle.html.erb
@@ -1,23 +1,16 @@
 <div id='js_tv_series_viewings_buttons_toggle'>
   <% if current_user.tv_series_viewings.active.find_by(show_id: show_id).present? %>
     <div class='manage-screenings'>
-      <%= button_to '<span class="material-symbols-outlined">bookmark_remove</span> Mark as Finished Watching'.html_safe, tv_series_viewing_path(
-          id: show_id,
-          show_id: show_id,
-          title: title,
-        ),
+      <%= button_to '<span class="material-symbols-outlined">bookmark_remove</span> Mark as Finished Watching'.html_safe, 
+        tv_series_viewing_path(id: show_id, show_id: show_id, title: title),
         method: :patch,
-        id: 'js_mark_finished_watching_link',
         remote: true %>
     </div>
   <% else %>
     <div class='manage-screenings'>
-      <%= button_to '<span class="material-symbols-outlined">bookmark_add</span> Add to Currently-Watching'.html_safe, tv_series_viewings_path(
-          show_id: show_id,
-          title: title,
-        ),
+      <%= button_to '<span class="material-symbols-outlined">bookmark_add</span> Add to Currently-Watching'.html_safe, 
+        tv_series_viewings_path(show_id: show_id, title: title),
         method: :post,
-        id: 'js_mark_currently_watching_link',
         remote: true %>
     </div>
   <% end %>

--- a/app/views/tv_series_viewings/_buttons_toggle.html.erb
+++ b/app/views/tv_series_viewings/_buttons_toggle.html.erb
@@ -1,0 +1,24 @@
+<div id='js_tv_series_viewings_buttons_toggle'>
+  <% if current_user.tv_series_viewings.active.find_by(show_id: show_id).present? %>
+    <div class='manage-screenings'>
+      <%= button_to '<span class="material-symbols-outlined">bookmark_remove</span> Mark as Finished Watching'.html_safe, tv_series_viewing_path(
+          id: show_id,
+          show_id: show_id,
+          title: title,
+        ),
+        method: :patch,
+        id: 'js_mark_finished_watching_link',
+        remote: true %>
+    </div>
+  <% else %>
+    <div class='manage-screenings'>
+      <%= button_to '<span class="material-symbols-outlined">bookmark_add</span> Add to Currently-Watching'.html_safe, tv_series_viewings_path(
+          show_id: show_id,
+          title: title,
+        ),
+        method: :post,
+        id: 'js_mark_currently_watching_link',
+        remote: true %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/tv_series_viewings/_navbar_dropdown.html.erb
+++ b/app/views/tv_series_viewings/_navbar_dropdown.html.erb
@@ -1,0 +1,13 @@
+<% if current_user.tv_series_viewings.any? %>
+  <li id="js_main_nav_tv_series_viewings" class="dropdown-header">
+    <input id="my-shows" type="checkbox" name="my-shows" />
+    <label for="my-shows">My Shows</label>
+    <ul class="dropdown-items">
+      <li><%= link_to 'See Viewing History', tv_series_viewings_path %></li>
+      <hr>
+        <% current_user.tv_series_viewings.active.each do |show| %>
+          <li><%= link_to show.title, show.url %></li>
+        <% end %>
+    </ul>
+  </li>
+<% end %>

--- a/app/views/tv_series_viewings/_viewing_table_row.html.erb
+++ b/app/views/tv_series_viewings/_viewing_table_row.html.erb
@@ -1,0 +1,14 @@
+<%= tag.tr id: dom_id(viewing) do %>
+  <td><%= link_to viewing.title, viewing.url %></td>
+  <td><%= viewing.started_at.stamp("1/2/2001") %></td>
+  <td>
+    <% if viewing.active? %>
+      <%= button_to 'Mark as Finished Watching', 
+          tv_series_viewing_path(id: viewing.id, show_id: viewing.show_id, title: viewing.title),
+          method: :patch,
+          remote: true %>
+    <% else %>
+      <%= viewing.ended_at.stamp("1/2/2001") %>
+    <% end %>
+  </td>
+<% end %>

--- a/app/views/tv_series_viewings/create.turbo_stream.erb
+++ b/app/views/tv_series_viewings/create.turbo_stream.erb
@@ -1,0 +1,13 @@
+<!-- Replace the toggle buttons -->
+<%= turbo_stream.replace "js_tv_series_viewings_buttons_toggle" do %>
+  <%= render "tv_series_viewings/buttons_toggle", 
+    show_id: @viewing.show_id, 
+    title: @viewing.title 
+  %>
+<% end %>
+
+<!-- Replace the navbar dropdown with currently active shows -->
+<%= turbo_stream.replace "js_main_nav_tv_series_viewings" do %>
+  <%= render 'tv_series_viewings/navbar_dropdown' %>
+<% end %>
+

--- a/app/views/tv_series_viewings/index.html.erb
+++ b/app/views/tv_series_viewings/index.html.erb
@@ -1,0 +1,24 @@
+<% content_for(:title, "TV Series Viewings") %>
+
+<h1>My TV Series Viewings</h1>
+
+<table width="100%">
+  <thead>
+    <tr>
+      <th>TV Series</th>
+      <th>Started Watching</th>
+      <th>Stopped Watching</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @viewings.order(ended_at: :desc).each do |viewing| %>
+      <tr>
+        <td><%= link_to viewing.title, viewing.url %></td>
+        <td><%= viewing.started_at.stamp("1/2/2001") %></td>
+        <td><%= viewing.ended_at&.stamp("1/2/2001") %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+

--- a/app/views/tv_series_viewings/index.html.erb
+++ b/app/views/tv_series_viewings/index.html.erb
@@ -11,7 +11,7 @@
     </tr>
   </thead>
   <tbody>
-    <% @viewings.order(ended_at: :desc).each do |viewing| %>
+    <% @viewings.order(ended_at: :desc, started_at: :desc).each do |viewing| %>
       <tr>
         <td><%= link_to viewing.title, viewing.url %></td>
         <td><%= viewing.started_at.stamp("1/2/2001") %></td>

--- a/app/views/tv_series_viewings/index.html.erb
+++ b/app/views/tv_series_viewings/index.html.erb
@@ -12,11 +12,7 @@
   </thead>
   <tbody>
     <% @viewings.order(ended_at: :desc, started_at: :desc).each do |viewing| %>
-      <tr>
-        <td><%= link_to viewing.title, viewing.url %></td>
-        <td><%= viewing.started_at.stamp("1/2/2001") %></td>
-        <td><%= viewing.ended_at&.stamp("1/2/2001") %></td>
-      </tr>
+      <%= render partial: 'viewing_table_row', locals: { viewing: viewing } %>
     <% end %>
   </tbody>
 </table>

--- a/app/views/tv_series_viewings/update.turbo_stream.erb
+++ b/app/views/tv_series_viewings/update.turbo_stream.erb
@@ -11,3 +11,7 @@
   <%= render 'tv_series_viewings/navbar_dropdown' %>
 <% end %>
 
+<!-- Replace the row in the index page table -->
+<%= turbo_stream.replace dom_id(@viewing) do %>
+  <%= render partial: 'viewing_table_row', locals: { viewing: @viewing } %>
+<% end %>

--- a/app/views/tv_series_viewings/update.turbo_stream.erb
+++ b/app/views/tv_series_viewings/update.turbo_stream.erb
@@ -1,0 +1,13 @@
+<!-- Replace the toggle buttons -->
+<%= turbo_stream.replace "js_tv_series_viewings_buttons_toggle" do %>
+  <%= render "tv_series_viewings/buttons_toggle", 
+    show_id: @viewing.show_id, 
+    title: @viewing.title 
+  %>
+<% end %>
+
+<!-- Replace the navbar dropdown with currently active shows -->
+<%= turbo_stream.replace "js_main_nav_tv_series_viewings" do %>
+  <%= render 'tv_series_viewings/navbar_dropdown' %>
+<% end %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   end
 
   resources :screenings, only: :create
-  resources :tv_series_viewings, only: :index
+  resources :tv_series_viewings, only: [:index, :create, :update]
 
   post 'movies/modal', to: 'movies#modal', as: :movie_modal
   get 'movies/modal_close', to: 'movies#modal_close', as: :movie_modal_close

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   end
 
   resources :screenings, only: :create
+  resources :tv_series_viewings, only: :index
 
   post 'movies/modal', to: 'movies#modal', as: :movie_modal
   get 'movies/modal_close', to: 'movies#modal_close', as: :movie_modal_close

--- a/db/migrate/20241211180716_create_tv_series_viewings.rb
+++ b/db/migrate/20241211180716_create_tv_series_viewings.rb
@@ -1,6 +1,6 @@
 class CreateTVSeriesViewings < ActiveRecord::Migration[7.1]
   def change
-    create_table :tv_series_viewings do |t|
+    create_table :tv_series_viewings, id: :uuid do |t|
       t.references :user, null: false, foreign_key: true
       t.string :title, null: false
       t.string :url, null: false

--- a/db/migrate/20241211180716_create_tv_series_viewings.rb
+++ b/db/migrate/20241211180716_create_tv_series_viewings.rb
@@ -1,0 +1,16 @@
+class CreateTVSeriesViewings < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tv_series_viewings do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title, null: false
+      t.string :url, null: false
+      t.string :show_id, null: false
+      t.datetime :started_at, null: false
+      t.datetime :ended_at
+      t.timestamps
+    end
+
+    add_index :tv_series_viewings, :show_id
+    add_index :tv_series_viewings, :ended_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_05_205326) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_11_180716) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -141,6 +141,20 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_05_205326) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
+  create_table "tv_series_viewings", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "title", null: false
+    t.string "url", null: false
+    t.string "show_id", null: false
+    t.datetime "started_at", null: false
+    t.datetime "ended_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ended_at"], name: "index_tv_series_viewings_on_ended_at"
+    t.index ["show_id"], name: "index_tv_series_viewings_on_show_id"
+    t.index ["user_id"], name: "index_tv_series_viewings_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -180,4 +194,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_05_205326) do
   add_foreign_key "taggings", "movies"
   add_foreign_key "taggings", "tags"
   add_foreign_key "taggings", "users"
+  add_foreign_key "tv_series_viewings", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -141,7 +141,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_11_180716) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "tv_series_viewings", force: :cascade do |t|
+  create_table "tv_series_viewings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "title", null: false
     t.string "url", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,34 +13,4 @@
   user.admin = true
 end
 
-user.tv_series_viewings.find_or_create_by(
-  title: 'Brooklyn Nine Nine',
-  url: '/tmdb/tv_series?show_id=48891',
-  show_id: '48891',
-  started_at: 2.weeks.ago,
-  ended_at: nil
-)
-
-user.tv_series_viewings.find_or_create_by(
-  title: 'Star Trek: The Next Generation',
-  url: '/tmdb/tv_series?show_id=655',
-  show_id: '655',
-  started_at: '2023-04-01'.to_datetime,
-  ended_at: '2024-05-27'.to_datetime
-)
-
-user.tv_series_viewings.find_or_create_by(
-  title: 'DS9',
-  url: '/tmdb/tv_series?show_id=580',
-  show_id: '580',
-  started_at: '2021-06-13'.to_datetime,
-  ended_at: '2023-01-23'.to_datetime
-)
-
-user.tv_series_viewings.find_or_create_by(
-  title: 'Star Trek: The Next Generation',
-  url: '/tmdb/tv_series?show_id=655',
-  show_id: '655',
-  started_at: '2019-12-28'.to_datetime,
-  ended_at: '2001-06-12'.to_datetime
-)
+Rake::Task["db:seed:tv_series_viewings"].invoke(user.id)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,26 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+ user = User.find_or_create_by(email: 'admin@email.com') do |user|
+  user.password = 'password'
+  user.password_confirmation = 'password'
+  user.username = 'McAdmins'
+  user.admin = true
+end
+
+user.tv_series_viewings.find_or_create_by(
+  title: 'Brooklyn Nine Nine',
+  url: '/tmdb/tv_series?show_id=48891',
+  show_id: '48891',
+  started_at: 2.weeks.ago,
+  ended_at: nil
+)
+
+user.tv_series_viewings.find_or_create_by(
+  title: 'DS9',
+  url: '/tmdb/tv_series?show_id=580',
+  show_id: '580',
+  started_at: '2024-03-01'.to_datetime,
+  ended_at: '2024-12-10'.to_datetime
+)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,9 +22,25 @@ user.tv_series_viewings.find_or_create_by(
 )
 
 user.tv_series_viewings.find_or_create_by(
+  title: 'Star Trek: The Next Generation',
+  url: '/tmdb/tv_series?show_id=655',
+  show_id: '655',
+  started_at: '2023-04-01'.to_datetime,
+  ended_at: '2024-05-27'.to_datetime
+)
+
+user.tv_series_viewings.find_or_create_by(
   title: 'DS9',
   url: '/tmdb/tv_series?show_id=580',
   show_id: '580',
-  started_at: '2024-03-01'.to_datetime,
-  ended_at: '2024-12-10'.to_datetime
+  started_at: '2021-06-13'.to_datetime,
+  ended_at: '2023-01-23'.to_datetime
+)
+
+user.tv_series_viewings.find_or_create_by(
+  title: 'Star Trek: The Next Generation',
+  url: '/tmdb/tv_series?show_id=655',
+  show_id: '655',
+  started_at: '2019-12-28'.to_datetime,
+  ended_at: '2001-06-12'.to_datetime
 )

--- a/lib/tasks/seed/tv_series_viewings.rake
+++ b/lib/tasks/seed/tv_series_viewings.rake
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+namespace :db do
+  namespace :seed do
+    desc "Create TVSeriesViewing Seeds"
+    task :tv_series_viewings, [:user_id] => [:environment] do |_task, args|
+
+      if !args[:user_id]
+        puts "ERROR: user_id is required for tv_series_viewings seeds."
+        puts "\nRun from the command line with:"
+        puts "rails 'db:seed:tv_series_viewings[USER-ID-HERE]'"
+        puts "\nOr inside the rails console with:"
+        puts "Rails.application.load_tasks"
+        puts 'Rake::Task["db:seed:tv_series_viewings"].invoke(user.id)'
+        exit 1
+      end
+
+      user = User.find(args[:user_id])
+     
+      puts "Seeding TVSeriesViewings"
+      user.tv_series_viewings.find_or_create_by(
+        title: 'Brooklyn Nine Nine',
+        url: '/tmdb/tv_series?show_id=48891',
+        show_id: '48891',
+        started_at: '2024-12-10'.to_datetime,
+        ended_at: nil
+      )
+
+      user.tv_series_viewings.find_or_create_by(
+        title: 'Star Trek: The Next Generation',
+        url: '/tmdb/tv_series?show_id=655',
+        show_id: '655',
+        started_at: '2023-04-01'.to_datetime,
+        ended_at: '2024-05-27'.to_datetime
+      )
+
+      user.tv_series_viewings.find_or_create_by(
+        title: 'DS9',
+        url: '/tmdb/tv_series?show_id=580',
+        show_id: '580',
+        started_at: '2021-06-13'.to_datetime,
+        ended_at: '2023-01-23'.to_datetime
+      )
+
+      user.tv_series_viewings.find_or_create_by(
+        title: 'Star Trek: The Next Generation',
+        url: '/tmdb/tv_series?show_id=655',
+        show_id: '655',
+        started_at: '2019-12-28'.to_datetime,
+        ended_at: '2001-06-12'.to_datetime
+      )
+
+      puts "Finished."
+    end
+  end
+end

--- a/spec/factories/tv_series_viewings.rb
+++ b/spec/factories/tv_series_viewings.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :tv_series_viewing do
+    user
+    title { FFaker::HipsterIpsum.phrase }
+    sequence(:url) { |n| "/example/#{n}" }
+    sequence(:show_id) { |n| n * 100 }
+    started_at { 1.week.ago }
+
+    factory :invalid_tv_series_viewing do
+      started_at { nil }
+    end
+  end
+end

--- a/spec/models/tv_series_viewing_spec.rb
+++ b/spec/models/tv_series_viewing_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe TVSeriesViewing, type: :model do
+  
+  context 'with a valid factory' do
+    let(:tv_series_viewing) { build(:tv_series_viewing) }
+    it 'has a valid factory' do
+      expect(tv_series_viewing).to be_valid
+    end
+  end
+  
+  context 'without a valid factory' do
+    let(:invalid_tv_series_viewing) { build(:invalid_tv_series_viewing) }
+    it 'has an invalid factory' do
+      expect(invalid_tv_series_viewing).not_to be_valid
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:url) }
+    it { is_expected.to validate_presence_of(:show_id) }
+    it { is_expected.to validate_presence_of(:started_at) }
+  end
+end

--- a/spec/models/tv_series_viewing_spec.rb
+++ b/spec/models/tv_series_viewing_spec.rb
@@ -21,5 +21,72 @@ RSpec.describe TVSeriesViewing, type: :model do
     it { is_expected.to validate_presence_of(:url) }
     it { is_expected.to validate_presence_of(:show_id) }
     it { is_expected.to validate_presence_of(:started_at) }
+
+    describe "preventing a user from creating duplicate active viewings for the same series" do
+      let(:user) { create(:user) }
+      let(:show_id) { '123' }
+      let(:original_tv_series_viewing) { create(:tv_series_viewing, user: user, show_id: show_id, ended_at: original_viewing_ending_timestamp) }
+      
+      context "when the user has an existing inactive viewing for the series" do
+        let(:original_viewing_ending_timestamp) { '2024-05-01'.to_datetime }
+        let(:new_tv_series_viewing) { build(:tv_series_viewing, user: original_tv_series_viewing.user, show_id: original_tv_series_viewing.show_id ) }
+
+        it "creating a new viewing for the same series is valid" do
+          expect(original_tv_series_viewing.active?).to be(false)
+          expect(new_tv_series_viewing).to be_valid
+        end
+      end
+
+      context "when the user has an existing active viewing for the series" do
+        let(:original_viewing_ending_timestamp) { nil }
+        let(:new_tv_series_viewing) { build(:tv_series_viewing, user: original_tv_series_viewing.user, show_id: original_tv_series_viewing.show_id ) }
+
+        it "creating a new viewing for the same series is not valid" do
+          expect(original_tv_series_viewing.active?).to be(true)
+          expect(new_tv_series_viewing).to_not be_valid
+        end
+      end
+      
+      context "when the user has an existing active viewing for the series and another user want to start that series" do
+        let(:original_viewing_ending_timestamp) { nil }
+        let(:another_user) { create(:user) }
+        let(:new_tv_series_viewing) { build(:tv_series_viewing, user: another_user, show_id: original_tv_series_viewing.show_id ) }
+
+        it "creating a new viewing for the same series is valid" do
+          expect(original_tv_series_viewing.active?).to be(true)
+          expect(new_tv_series_viewing).to be_valid
+        end
+      end
+    end
+  end
+
+  describe "scopes" do
+    describe "active" do
+      let(:active_tv_series_viewing) { create(:tv_series_viewing, ended_at: nil) }
+      let(:inactive_tv_series_viewing) { create(:tv_series_viewing, ended_at: '2024-05-01'.to_date) }
+      it "includes active viewings" do
+        expect(described_class.active).to include(active_tv_series_viewing)
+      end
+
+      it "excludes inactive viewings" do
+        expect(described_class.active).to_not include(inactive_tv_series_viewing)
+      end
+    end
+  end
+
+  describe "active?" do
+    context "when a viewing is currently active" do
+      let(:tv_series_viewing) { build(:tv_series_viewing, ended_at: nil) }
+      it "returns true" do
+        expect(tv_series_viewing.active?).to eq(true)
+      end
+    end
+
+    context "when a viewing is currently inactive" do
+      let(:tv_series_viewing) { build(:tv_series_viewing, ended_at: '2024-05-01'.to_date) }
+      it "returns false" do
+        expect(tv_series_viewing.active?).to eq(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Related Issues & PRs
Closes #443
Closes #444
Closes #445 
Closes #446
Closes #447
Closes #449

## Features Added
* Converts global hard coded "Quick Links" dropdown into user-based, db-backed version
* Allows adding/removing to the dropdown via buttons on the TV Series page
* Provides history page so users can see their TV Series viewing history over time
* Allows users to watch a series multiple times

## Screenshots
Before: Navbar with hardcoded links
<img width="408" alt="Screenshot 2024-12-11 at 8 55 40 AM" src="https://github.com/user-attachments/assets/c76ea915-aa77-46d3-b87c-b22ec89be78f" />

After: Navbar with dynamic links. Also consolidated "My Movies" into the "My Lists" page. On full screen, there is a menu option to see user settings. 
<img width="421" alt="Screenshot 2024-12-11 at 6 48 48 PM" src="https://github.com/user-attachments/assets/311b71a6-ee82-4438-ae90-e89570334240" />


After: Button added to TV Series page that allow adding to the dropdown
<img width="422" alt="Image" src="https://github.com/user-attachments/assets/a39bfe2e-5df0-46ca-8d14-952b58d1945e" />

After: Button added to TV Series page that removing adding from the dropdown
<img width="421" alt="Image" src="https://github.com/user-attachments/assets/ec82a2b5-8d58-4a97-8edf-e3078ebc30cd" />

After: Index page for TV Series Viewings allows users to view history over time. Can also click button to mark a series as finished and remove it from the dropdown.
<img width="419" alt="Image" src="https://github.com/user-attachments/assets/3548bf7b-58db-492d-b626-452da9d66151" />


## Due diligence checks
- [x] check that migration script will deploy automatically 
- [x] run whole spec suite locally
- [ ] do I need to write more specs?
- [ ] look into chromedriver
- [x] move seeds into data tasks
