### PR TITLE
Edit tv series viewings

### DIFF
--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -126,7 +126,7 @@ class TmdbController < ApplicationController
   def tv_series
     show_id = params[:show_id]
     @media = TVSeriesDataService.get_tv_series_data(show_id)
-    @tv_series_viewing = current_user.tv_series_viewings.active.find_by(show_id: show_id)
+    @active_tv_series_viewing = current_user.tv_series_viewings.active.find_by(show_id: show_id)
   end
 
   def tv_season

--- a/app/controllers/tmdb_controller.rb
+++ b/app/controllers/tmdb_controller.rb
@@ -126,6 +126,7 @@ class TmdbController < ApplicationController
   def tv_series
     show_id = params[:show_id]
     @media = TVSeriesDataService.get_tv_series_data(show_id)
+    @tv_series_viewing = current_user.tv_series_viewings.active.find_by(show_id: show_id)
   end
 
   def tv_season

--- a/app/controllers/tv_series_viewings_controller.rb
+++ b/app/controllers/tv_series_viewings_controller.rb
@@ -1,12 +1,16 @@
 class TVSeriesViewingsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_tv_series_viewing, only: [:edit, :update, :destroy]
 
   def index
-    @viewings = current_user.tv_series_viewings
+    @tv_series_viewings = current_user.tv_series_viewings
+  end
+
+  def edit
   end
 
   def create
-    @viewing = current_user.tv_series_viewings.new(
+    @tv_series_viewing = current_user.tv_series_viewings.new(
       title: params[:title],
       show_id: params[:show_id],
       url: tv_series_path(show_id: params[:show_id]),
@@ -14,7 +18,7 @@ class TVSeriesViewingsController < ApplicationController
     )
 
     respond_to do |format|
-      if @viewing.save
+      if @tv_series_viewing.save
         format.turbo_stream {}
         format.html { redirect_to tv_series_path(show_id: params[:show_id]), notice: 'Added to Currently Watching List.' }
       else
@@ -24,15 +28,29 @@ class TVSeriesViewingsController < ApplicationController
   end
 
   def update
-    @viewing = current_user.tv_series_viewings.active.find_by(show_id: params[:show_id])
-
     respond_to do |format|
-      if @viewing.update(ended_at: Time.current)
+      if @tv_series_viewing.update(tv_series_viewing_params)
+        @active_tv_series_viewing = current_user.tv_series_viewings.active.find_by(show_id: @tv_series_viewing.show_id)
         format.turbo_stream {}
-        format.html { redirect_to tv_series_path(show_id: params[:show_id]), notice: 'Removed from Currently Watching List.' }
+        format.html { redirect_to tv_series_viewings_path, notice: 'Removed from Currently Watching List.' }
       else
-        format.html { redirect_to tv_series_path(show_id: params[:show_id]), error: 'Could not remove from Currently Watching List.' }
+        format.html { redirect_to tv_series_viewings_path, error: 'Could not remove from Currently Watching List.' }
       end
     end
+  end
+
+  def destroy
+    @tv_series_viewing.destroy
+    redirect_to tv_series_viewings_path, notice: 'Successfully deleted viewing.'
+  end
+
+  private
+
+  def set_tv_series_viewing
+    @tv_series_viewing = current_user.tv_series_viewings.find(params[:id])
+  end
+
+  def tv_series_viewing_params
+    params.require(:tv_series_viewing).permit(:show_id, :title, :started_at, :ended_at, :user_id)
   end
 end

--- a/app/controllers/tv_series_viewings_controller.rb
+++ b/app/controllers/tv_series_viewings_controller.rb
@@ -17,23 +17,29 @@ class TVSeriesViewingsController < ApplicationController
       started_at: Time.current
     )
 
-    respond_to do |format|
-      if @tv_series_viewing.save
-        format.turbo_stream {}
+    if @tv_series_viewing.save
+      respond_to do |format|
+        format.turbo_stream
         format.html { redirect_to tv_series_path(show_id: params[:show_id]), notice: 'Added to Currently Watching List.' }
-      else
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream { redirect_to tv_series_path(show_id: params[:show_id]), error: 'Could not add to Currently Watching List.' }
         format.html { redirect_to tv_series_path(show_id: params[:show_id]), error: 'Could not add to Currently Watching List.' }
       end
     end
   end
 
   def update
-    respond_to do |format|
-      if @tv_series_viewing.update(tv_series_viewing_params)
-        @active_tv_series_viewing = current_user.tv_series_viewings.active.find_by(show_id: @tv_series_viewing.show_id)
-        format.turbo_stream {}
+    if @tv_series_viewing.update(tv_series_viewing_params)
+      @active_tv_series_viewing = current_user.tv_series_viewings.active.find_by(show_id: @tv_series_viewing.show_id)
+      respond_to do |format|
+        format.turbo_stream
         format.html { redirect_to tv_series_viewings_path, notice: 'Removed from Currently Watching List.' }
-      else
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream { redirect_to tv_series_path(show_id: params[:show_id]), error: 'Could not remove from Currently Watching List.' }
         format.html { redirect_to tv_series_viewings_path, error: 'Could not remove from Currently Watching List.' }
       end
     end

--- a/app/views/shared/_tv_series_profile_content.html.erb
+++ b/app/views/shared/_tv_series_profile_content.html.erb
@@ -9,7 +9,7 @@
       ) if media.poster_path.present? %>
 
       <div class="screenings-providers-container">
-        <%= render "tv_series_viewings/buttons_toggle", show_id: media.show_id, title: media.show_name %>
+        <%= render "tv_series_viewings/buttons_toggle", active_tv_series_viewing: tv_series_viewing, show_id: media.show_id, title: media.show_name %>
         <%= render "shared/streaming_service_providers", streaming_service_providers: media.streaming_service_providers %>
       </div>
     </div>

--- a/app/views/shared/_tv_series_profile_content.html.erb
+++ b/app/views/shared/_tv_series_profile_content.html.erb
@@ -9,7 +9,7 @@
       ) if media.poster_path.present? %>
 
       <div class="screenings-providers-container">
-        <%= render "tv_series_viewings/buttons_toggle", active_tv_series_viewing: tv_series_viewing, show_id: media.show_id, title: media.show_name %>
+        <%= render "tv_series_viewings/buttons_toggle", active_tv_series_viewing: active_tv_series_viewing, show_id: media.show_id, title: media.show_name %>
         <%= render "shared/streaming_service_providers", streaming_service_providers: media.streaming_service_providers %>
       </div>
     </div>

--- a/app/views/tmdb/tv_series.html.erb
+++ b/app/views/tmdb/tv_series.html.erb
@@ -3,5 +3,5 @@
     <%= render 'shared/media_backdrop', media: @media %>
   <% end %>
 
-  <%= render "shared/tv_series_profile_content", media: @media %>
+  <%= render "shared/tv_series_profile_content", tv_series_viewing: @tv_series_viewing, media: @media %>
 </div>

--- a/app/views/tmdb/tv_series.html.erb
+++ b/app/views/tmdb/tv_series.html.erb
@@ -3,5 +3,5 @@
     <%= render 'shared/media_backdrop', media: @media %>
   <% end %>
 
-  <%= render "shared/tv_series_profile_content", tv_series_viewing: @tv_series_viewing, media: @media %>
+  <%= render "shared/tv_series_profile_content", active_tv_series_viewing: @active_tv_series_viewing, media: @media %>
 </div>

--- a/app/views/tv_series_viewings/_buttons_toggle.html.erb
+++ b/app/views/tv_series_viewings/_buttons_toggle.html.erb
@@ -1,8 +1,8 @@
 <div id='js_tv_series_viewings_buttons_toggle'>
-  <% if current_user.tv_series_viewings.active.find_by(show_id: show_id).present? %>
+  <% if active_tv_series_viewing.present? %>
     <div class='manage-screenings'>
       <%= button_to '<span class="material-symbols-outlined">bookmark_remove</span> Mark as Finished Watching'.html_safe, 
-        tv_series_viewing_path(id: show_id, show_id: show_id, title: title),
+        tv_series_viewing_path(id: active_tv_series_viewing.id, params: {tv_series_viewing: {ended_at: Time.current}}),
         method: :patch,
         remote: true %>
     </div>

--- a/app/views/tv_series_viewings/_navbar_dropdown.html.erb
+++ b/app/views/tv_series_viewings/_navbar_dropdown.html.erb
@@ -5,7 +5,7 @@
     <ul class="dropdown-items">
       <li><%= link_to 'See Viewing History', tv_series_viewings_path %></li>
       <hr>
-        <% current_user.tv_series_viewings.active.each do |show| %>
+        <% current_user.tv_series_viewings.active.order(title: :asc).each do |show| %>
           <li><%= link_to show.title, show.url %></li>
         <% end %>
     </ul>

--- a/app/views/tv_series_viewings/_viewing_table_row.html.erb
+++ b/app/views/tv_series_viewings/_viewing_table_row.html.erb
@@ -3,12 +3,10 @@
   <td><%= viewing.started_at.stamp("1/2/2001") %></td>
   <td>
     <% if viewing.active? %>
-      <%= button_to 'Mark as Finished Watching', 
-          tv_series_viewing_path(id: viewing.id, show_id: viewing.show_id, title: viewing.title),
-          method: :patch,
-          remote: true %>
+      Present
     <% else %>
       <%= viewing.ended_at.stamp("1/2/2001") %>
     <% end %>
   </td>
+  <td><%= link_to "Edit", edit_tv_series_viewing_path(viewing) %></td>
 <% end %>

--- a/app/views/tv_series_viewings/create.turbo_stream.erb
+++ b/app/views/tv_series_viewings/create.turbo_stream.erb
@@ -1,8 +1,9 @@
 <!-- Replace the toggle buttons -->
 <%= turbo_stream.replace "js_tv_series_viewings_buttons_toggle" do %>
-  <%= render "tv_series_viewings/buttons_toggle", 
-    show_id: @viewing.show_id, 
-    title: @viewing.title 
+  <%= render "tv_series_viewings/buttons_toggle",
+    active_tv_series_viewing: @tv_series_viewing, 
+    show_id: @tv_series_viewing.show_id, 
+    title: @tv_series_viewing.title 
   %>
 <% end %>
 

--- a/app/views/tv_series_viewings/edit.html.erb
+++ b/app/views/tv_series_viewings/edit.html.erb
@@ -1,0 +1,38 @@
+<% content_for(:title, "Edit Viewing Dates") %>
+
+<h1>Edit Viewing Dates for <%= link_to @tv_series_viewing.title, @tv_series_viewing.url %></h1>
+
+<%= form_with(model: @tv_series_viewing, data: {turbo: false}, html: {class: 'form'}) do |form| %>
+  <% if @tv_series_viewing.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(@tv_series_viewing.errors.count, "error") %> prohibited this tv_series_viewing from being saved:</h2>
+
+      <ul>
+        <% @tv_series_viewing.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :started_at, style: "display: block" %>
+    <%= form.date_field :started_at %>
+  </div>
+
+  <div>
+    <%= form.label :ended_at, style: "display: block" %>
+    <%= form.date_field :ended_at %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>
+
+<details class='mt-20 mb-20'>
+  <summary><h3 class='inline-block'>Delete?</h3></summary>
+
+  <p>Deleting this viewing cannot be undone.</p>
+  <%= button_to "Delete viewing", tv_series_viewing_path(@tv_series_viewing), data: { confirm: 'Are you sure?' }, method: :delete %>
+</details>

--- a/app/views/tv_series_viewings/index.html.erb
+++ b/app/views/tv_series_viewings/index.html.erb
@@ -8,10 +8,11 @@
       <th>TV Series</th>
       <th>Started Watching</th>
       <th>Stopped Watching</th>
+      <th></th>
     </tr>
   </thead>
   <tbody>
-    <% @viewings.order(ended_at: :desc, started_at: :desc).each do |viewing| %>
+    <% @tv_series_viewings.order(ended_at: :desc, started_at: :desc).each do |viewing| %>
       <%= render partial: 'viewing_table_row', locals: { viewing: viewing } %>
     <% end %>
   </tbody>

--- a/app/views/tv_series_viewings/update.turbo_stream.erb
+++ b/app/views/tv_series_viewings/update.turbo_stream.erb
@@ -1,8 +1,9 @@
 <!-- Replace the toggle buttons -->
 <%= turbo_stream.replace "js_tv_series_viewings_buttons_toggle" do %>
   <%= render "tv_series_viewings/buttons_toggle", 
-    show_id: @viewing.show_id, 
-    title: @viewing.title 
+    active_tv_series_viewing: @active_tv_series_viewing,
+    show_id: @tv_series_viewing.show_id, 
+    title: @tv_series_viewing.title 
   %>
 <% end %>
 
@@ -12,6 +13,6 @@
 <% end %>
 
 <!-- Replace the row in the index page table -->
-<%= turbo_stream.replace dom_id(@viewing) do %>
-  <%= render partial: 'viewing_table_row', locals: { viewing: @viewing } %>
+<%= turbo_stream.replace dom_id(@tv_series_viewing) do %>
+  <%= render partial: 'viewing_table_row', locals: { viewing: @tv_series_viewing } %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   end
 
   resources :screenings, only: :create
-  resources :tv_series_viewings, only: [:index, :create, :update]
+  resources :tv_series_viewings, only: [:index, :create, :edit, :update, :destroy]
 
   post 'movies/modal', to: 'movies#modal', as: :movie_modal
   get 'movies/modal_close', to: 'movies#modal_close', as: :movie_modal_close

--- a/spec/factories/tv_series_viewings.rb
+++ b/spec/factories/tv_series_viewings.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :tv_series_viewing do
     user
-    title { FFaker::HipsterIpsum.phrase }
+    sequence(:title) { |n| "TV Series #{n}" }
     sequence(:url) { |n| "/example/#{n}" }
     sequence(:show_id) { |n| n * 100 }
     started_at { 1.week.ago }

--- a/spec/requests/tv_series_viewings_spec.rb
+++ b/spec/requests/tv_series_viewings_spec.rb
@@ -154,46 +154,5 @@ RSpec.describe TVSeriesViewingsController, type: :request do
         expect(response).to redirect_to tv_series_viewings_url
       end
     end
-
-
-
-
-    # chatgpt
-    # let(:tv_series_viewing) { build(:tv_series_viewing) }
-    # let(:valid_params) { { tv_series_viewing: tv_series_viewing.attributes } }
-    # let(:user) { tv_series_viewing.user }
-    # describe 'POST #create' do
-    #   context 'when the request is made with Turbo' do
-    #     it 'responds with a Turbo Stream' do
-    #       post tv_series_viewings_path, params: valid_params, headers: { 'Turbo-Frame' => 'true' }
-
-    #       expect(response).to have_http_status(:ok)
-    #       expect(response.media_type).to eq('text/vnd.turbo-stream.html')
-    #       expect(response.body).to include('<turbo-stream') # Ensure it includes Turbo stream content
-    #     end
-
-    #     it 'creates a new TVSeriesViewing' do
-    #       expect {
-    #         post tv_series_viewings_path, params: valid_params, headers: { 'Turbo-Frame' => 'true' }
-    #       }.to change(TVSeriesViewing, :count).by(1)
-    #     end
-    #   end
-
-    #   context 'when the request is made as REST' do
-    #     it 'redirects to the index page' do
-    #       post tv_series_viewings_path, params: valid_params
-
-    #       expect(response).to have_http_status(:found)
-    #       expect(response).to redirect_to(tv_series_viewings_path)
-    #     end
-
-    #     it 'creates a new TVSeriesViewing' do
-    #       expect {
-    #         post tv_series_viewings_path, params: valid_params
-    #       }.to change(TVSeriesViewing, :count).by(1)
-    #     end
-    #   end
-    # end
-
   end
 end

--- a/spec/requests/tv_series_viewings_spec.rb
+++ b/spec/requests/tv_series_viewings_spec.rb
@@ -1,0 +1,199 @@
+require "rails_helper"
+
+RSpec.describe TVSeriesViewingsController, type: :request do
+  context "when the user is not authenticated" do
+    let(:tv_series_viewing) { create(:tv_series_viewing) }
+    let(:user) { tv_series_viewing.user }
+
+    it "GET #index redirects to the sign-in path" do
+      get tv_series_viewings_path
+      expect(response).to be_redirect
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "GET #edit redirects to the sign-in path" do
+      get edit_tv_series_viewing_path(tv_series_viewing)
+      expect(response).to be_redirect
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "POST #create redirects to the sign-in path" do
+      post tv_series_viewings_path(title: "foo", show_id: "123", url: "foo/", started_at: Time.current)
+      expect(response).to be_redirect
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "PATCH #update redirects to the sign-in path" do
+      # patch tv_series_viewing_path(id: tv_series_viewing.id, params: { ended_at: Time.current} )
+      patch tv_series_viewing_path(tv_series_viewing.id, params: { ended_at: Time.current} )
+      expect(response).to be_redirect
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "DELETE #destroy redirects to the sign-in path" do
+      delete tv_series_viewing_path(tv_series_viewing)
+      expect(response).to be_redirect
+      expect(response).to redirect_to new_user_session_path
+    end
+  end
+
+  context "when the user is authenticated" do
+    let(:tv_series_viewing) { create(:tv_series_viewing) }
+    let(:user) { tv_series_viewing.user }
+
+    before do
+      # sign_in(user)
+      allow_any_instance_of(TVSeriesViewingsController).to receive(:authenticate_user!).and_return(true)
+      allow_any_instance_of(TVSeriesViewingsController).to receive(:current_user).and_return(user)
+    end
+
+    describe "GET #index" do
+      it "is successful" do
+        get tv_series_viewings_path
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET #edit" do
+      it "is successful" do
+        get edit_tv_series_viewing_path(tv_series_viewing)
+        expect(response).to be_successful
+      end
+    end
+
+    describe "POST #create" do
+      let(:valid_params) { build(:tv_series_viewing).attributes}
+      
+      context "when it is a turbo request" do
+        let(:turbo_request) { post tv_series_viewings_path, params: valid_params, headers: { "Accept" => "text/vnd.turbo-stream.html" } }
+        
+        it "successfully renders a turbo response" do
+          turbo_request
+          expect(response).to have_http_status(:ok)
+          expect(response.media_type).to eq Mime[:turbo_stream]
+        end
+
+        it "renders the create template" do
+          turbo_request
+          expect(response).to render_template('tv_series_viewings/create')
+        end
+
+        it "creates a record" do
+          expect {
+            turbo_request
+          }.to change(TVSeriesViewing, :count)
+        end
+      end
+
+      context "when it is a rest request" do
+        let(:rest_request) { post tv_series_viewings_path, params: valid_params}
+
+        it "creates a record" do
+          expect {
+            rest_request
+          }.to change(TVSeriesViewing, :count)
+        end
+
+        it "redirects to the series page" do
+          rest_request
+          expect(response).to be_redirect
+          expect(response).to redirect_to tv_series_path(show_id: valid_params['show_id'])
+        end 
+        
+      end
+    end
+
+    describe "PATCH #update" do
+      let(:tv_series_viewing) { create(:tv_series_viewing, title: original_title) }
+      let(:original_title) {"Original Title" }
+      let(:changed_title) {"Changed Title" }
+
+      context "when it is a turbo request" do
+        let(:turbo_request) { patch tv_series_viewing_path(id: tv_series_viewing.id, format: :turbo_stream, params: {tv_series_viewing: {title: changed_title}}) }
+        
+        it "successfully renders a turbo response" do
+          turbo_request
+          expect(response).to have_http_status(:ok)
+
+        end  
+        
+        it "updates the record" do
+          turbo_request
+          expect(tv_series_viewing.reload.title).to eq(changed_title)
+        end
+      end
+      
+      context "when it is a rest request" do
+        let(:rest_request) { patch tv_series_viewing_path(tv_series_viewing, data: {turbo: false}, params: {tv_series_viewing: {title: changed_title}}) }
+
+        it "updates the record" do
+          rest_request
+          expect(tv_series_viewing.reload.title).to eq(changed_title)
+        end 
+
+        it "redirects to the index page" do
+          rest_request
+          expect(response).to be_redirect
+          expect(response).to redirect_to tv_series_viewings_path
+        end 
+      end
+    end
+
+    describe "DELETE #destroy" do
+      let(:tv_series_viewing) { create(:tv_series_viewing) }
+
+      it "destroys the record" do
+        expect {
+          delete tv_series_viewing_path(tv_series_viewing)
+        }.to change(TVSeriesViewing, :count)
+      end
+
+      it "is redirects to tv_series_viewings_url" do
+        delete tv_series_viewing_path(tv_series_viewing)
+        expect(response).to be_redirect
+        expect(response).to redirect_to tv_series_viewings_url
+      end
+    end
+
+
+
+
+    # chatgpt
+    # let(:tv_series_viewing) { build(:tv_series_viewing) }
+    # let(:valid_params) { { tv_series_viewing: tv_series_viewing.attributes } }
+    # let(:user) { tv_series_viewing.user }
+    # describe 'POST #create' do
+    #   context 'when the request is made with Turbo' do
+    #     it 'responds with a Turbo Stream' do
+    #       post tv_series_viewings_path, params: valid_params, headers: { 'Turbo-Frame' => 'true' }
+
+    #       expect(response).to have_http_status(:ok)
+    #       expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+    #       expect(response.body).to include('<turbo-stream') # Ensure it includes Turbo stream content
+    #     end
+
+    #     it 'creates a new TVSeriesViewing' do
+    #       expect {
+    #         post tv_series_viewings_path, params: valid_params, headers: { 'Turbo-Frame' => 'true' }
+    #       }.to change(TVSeriesViewing, :count).by(1)
+    #     end
+    #   end
+
+    #   context 'when the request is made as REST' do
+    #     it 'redirects to the index page' do
+    #       post tv_series_viewings_path, params: valid_params
+
+    #       expect(response).to have_http_status(:found)
+    #       expect(response).to redirect_to(tv_series_viewings_path)
+    #     end
+
+    #     it 'creates a new TVSeriesViewing' do
+    #       expect {
+    #         post tv_series_viewings_path, params: valid_params
+    #       }.to change(TVSeriesViewing, :count).by(1)
+    #     end
+    #   end
+    # end
+
+  end
+end


### PR DESCRIPTION
## Related Issues & PRs
Closes #488

## Problems Solved
* allows users to delete viewing records
* allows users to edit viewing records
* orders navbar dropdown items by title alpha ascending

## Screenshots
The button to mark a current show as finished is gone and now we're offering an edit link instead
<img width="417" alt="Screenshot 2024-12-15 at 1 43 16 PM" src="https://github.com/user-attachments/assets/6550a0b7-af07-4ce1-a291-a6c3f22f09c7" />

This is the edit form
<img width="411" alt="Screenshot 2024-12-15 at 1 43 49 PM" src="https://github.com/user-attachments/assets/664216fd-3cb6-4076-8882-e853ac2081ec" />

This is the navbar with shows ordered by title
<img width="416" alt="Screenshot 2024-12-15 at 2 06 15 PM" src="https://github.com/user-attachments/assets/05d4b732-028c-4543-a086-355efd7ee9d2" />


## Approach
There were several ways to do this work -- all of them seem to have tradeoffs. I settled on using `turbo: false` for the edit form and having the controller handle the different behaviors based on format. The behaviors are:
* when adding an item to the watching list via the toggle button, turbo handles DOM updates and the user stays on the tv series page
* when removing an item from the watching list via the toggle button, turbo handles DOM updates and the user stays on the tv series page
* when editing an item via the edit form, the html does a redirect back to the index page
