### PR TITLE
Add streaming service providers

### DIFF
--- a/app/assets/stylesheets/media-show-page.css
+++ b/app/assets/stylesheets/media-show-page.css
@@ -41,7 +41,7 @@ a.streaming-provider {
   top: 7px;
 }
 
-.txt-sm.avaliablity {
+.txt-sm.availability {
   font-size: 10px;
   margin-top: 20px;
 }

--- a/app/services/streaming_service_provider_data_service.rb
+++ b/app/services/streaming_service_provider_data_service.rb
@@ -5,54 +5,94 @@ module StreamingServiceProviderDataService
     def get_providers(tmdb_id:, title:, media_type:, media_format:, release_date: nil)
       params = { tmdb_id: tmdb_id, media_type: media_type }
       results = Tmdb::Client.request(:streaming_service_providers, params)&.dig(:results, :US)
-
+binding.pry
       parameterized_title = title.parameterize(separator: '+')
       default_providers = [
         # Find more providers at TMDB's watch_provider partner: https://www.justwatch.com/us
         {
-          name: 'Hoopla',
+          display_name: 'Hoopla',
+          tmdb_provider_name: 'Hoopla',
+          tmdb_provider_id: 212,
           pay_model: 'try',
           url: "https://www.hoopladigital.com/search?q=#{parameterized_title}&scope=everything&type=direct&kindId=7"
         },
         {
-          name: 'Netflix',
+          display_name: 'Kanopy',
+          tmdb_provider_name: 'Kanopy',
+          tmdb_provider_id: 191,
+          pay_model: 'try',
+          url: "https://www.kanopy.com"
+        },
+        {
+          display_name: 'Netflix',
+          tmdb_provider_name: 'Netflix',
+          tmdb_provider_id: 8,
           pay_model: 'try',
           url: "http://www.netflix.com/search/?q=#{title}"
         },
         {
-          name: 'Amazon Prime Video',
+          display_name: 'Amazon',
+          tmdb_provider_name: 'Amazon Prime Video',
+          tmdb_provider_id: 9,
           pay_model: 'try',
           url: "https://www.amazon.com/s?k=#{parameterized_title}&i=instant-video"
         },
         {
-          name: 'Amazon Video',
+          display_name: 'Amazon',
+          tmdb_provider_name: 'Amazon Video',
+          tmdb_provider_id: 10,
           pay_model: 'try',
           url: "https://www.amazon.com/s?k=#{parameterized_title}&i=instant-video"
         },
         {
-          name: 'YouTube',
+          display_name: 'YouTube',
+          tmdb_provider_name: 'YouTube',
+          tmdb_provider_id: 192,
           pay_model: 'try',
           url: "https://www.youtube.com/results?search_query=#{parameterized_title}+full+#{media_format} #{release_date&.stamp('2001')}"
         },
         {
-          name: 'Vudu',
+          display_name: 'Fandango',
+          tmdb_provider_name: 'Fandango At Home',
+          tmdb_provider_id: 7,
           pay_model: 'try',
-          url: "https://www.vudu.com/content/movies/search?searchString=#{title}"
+          url: "https://athome.fandango.com/content/movies/search?searchString=#{title}"
+        },
+        # {
+        #   display_name: 'VUDU',
+        #   tmdb_provider_name: 'VUDU Free',
+        #   tmdb_provider_id: 332,
+        #   pay_model: 'try',
+        #   url: "https://athome.fandango.com/content/movies/search?searchString=#{title}"
+        # },
+        {
+          display_name: 'Peacock',
+          tmdb_provider_name: 'Peacock Premium',
+          tmdb_provider_id: 386,
+          pay_model: 'try',
+          url: "https://www.peacocktv.com/"
+        },
+        {
+          display_name: 'Peacock+',
+          tmdb_provider_name: 'Peacock Premium Plus',
+          tmdb_provider_id: 387,
+          pay_model: 'try',
+          url: "https://www.peacocktv.com/"
         },
       ]
       return default_providers if results.nil?
 
-      free_provider_names = results[:free]&.map { |result| result[:provider_name] } || []
-      flatrate_provider_names = results[:flatrate]&.map { |result| result[:provider_name] } || []
-      rent_provider_names = results[:rent]&.map { |result| result[:provider_name] } || []
-      buy_provider_names = results[:buy]&.map { |result| result[:provider_name] } || []
+      result_free_provider_ids = results[:free]&.map { |result| result[:provider_id] } || []
+      result_flatrate_provider_ids = results[:flatrate]&.map { |result| result[:provider_id] } || []
+      result_rent_provider_ids = results[:rent]&.map { |result| result[:provider_id] } || []
+      result_buy_provider_ids = results[:buy]&.map { |result| result[:provider_id] } || []
 
       default_providers.map do |provider|
-        pay_model = if flatrate_provider_names.include?(provider[:name]) || free_provider_names.include?(provider[:name])
+        pay_model = if result_flatrate_provider_ids.include?(provider[:tmdb_provider_id]) || result_free_provider_ids.include?(provider[:tmdb_provider_id])
           'free'
-        elsif rent_provider_names.include?(provider[:name])
+        elsif result_rent_provider_ids.include?(provider[:tmdb_provider_id])
           'rent'
-        elsif buy_provider_names.include?(provider[:name])
+        elsif result_buy_provider_ids.include?(provider[:tmdb_provider_id])
           'buy'
         else
           'try'

--- a/app/services/streaming_service_provider_data_service.rb
+++ b/app/services/streaming_service_provider_data_service.rb
@@ -5,7 +5,7 @@ module StreamingServiceProviderDataService
     def get_providers(tmdb_id:, title:, media_type:, media_format:, release_date: nil)
       params = { tmdb_id: tmdb_id, media_type: media_type }
       results = Tmdb::Client.request(:streaming_service_providers, params)&.dig(:results, :US)
-binding.pry
+
       parameterized_title = title.parameterize(separator: '+')
       default_providers = [
         # Find more providers at TMDB's watch_provider partner: https://www.justwatch.com/us

--- a/app/views/movies/mini_modal/_streaming_service_providers.html.erb
+++ b/app/views/movies/mini_modal/_streaming_service_providers.html.erb
@@ -16,5 +16,5 @@
     <% end %>
   <% end %>
 
-  <p class='txt-sm avaliablity'>Availability data by <%= link_to 'JustWatch', 'https://www.justwatch.com', target: '_blank' %></p>
+  <p class='txt-sm availability'>Availability data by <%= link_to 'JustWatch', 'https://www.justwatch.com', target: '_blank' %></p>
 </div>

--- a/app/views/movies/mini_modal/_streaming_service_providers.html.erb
+++ b/app/views/movies/mini_modal/_streaming_service_providers.html.erb
@@ -1,18 +1,18 @@
 <div class="streaming-providers mt-10">
   <!--TODO: this is a temporary hack for MVP-->
   <% if streaming_service_providers.filter { |p| p[:pay_model] == 'free' }.blank? %>
-    <% streaming_service_providers.filter { |p| p[:display_name] == 'Amazon Video' }.each do |provider| %>
+    <% streaming_service_providers.filter { |p| p[:tmdb_provider_name] == 'Amazon Video' }.each do |provider| %>
       <a href="<%= provider[:url] %>" target="_blank" alt="<%= provider[:display_name] %>" title="<%= provider[:display_name] %>" class='streaming-provider'>
         <span class="material-symbols-outlined"><%= display_pay_model_icon(provider[:pay_model]) %></span>
           <%= provider[:pay_model].titleize %> on <%= provider[:display_name] %>
-        </a>
+      </a>
     <% end %>
   <% else %>
     <% streaming_service_providers.filter { |p| p[:pay_model] == 'free' }.each do |provider| %>
       <a href="<%= provider[:url] %>" target="_blank" alt="<%= provider[:display_name] %>" title="<%= provider[:display_name] %>" class='streaming-provider'>
         <span class="material-symbols-outlined"><%= display_pay_model_icon(provider[:pay_model]) %></span>
           <%= provider[:pay_model].titleize %> on <%= provider[:display_name] %>
-        </a>
+      </a>
     <% end %>
   <% end %>
 

--- a/app/views/movies/mini_modal/_streaming_service_providers.html.erb
+++ b/app/views/movies/mini_modal/_streaming_service_providers.html.erb
@@ -1,17 +1,17 @@
 <div class="streaming-providers mt-10">
   <!--TODO: this is a temporary hack for MVP-->
   <% if streaming_service_providers.filter { |p| p[:pay_model] == 'free' }.blank? %>
-    <% streaming_service_providers.filter { |p| p[:name] == 'Amazon Video' }.each do |provider| %>
-      <a href="<%= provider[:url] %>" target="_blank" alt="<%= provider[:name] %>" title="<%= provider[:name] %>" class='streaming-provider'>
+    <% streaming_service_providers.filter { |p| p[:display_name] == 'Amazon Video' }.each do |provider| %>
+      <a href="<%= provider[:url] %>" target="_blank" alt="<%= provider[:display_name] %>" title="<%= provider[:display_name] %>" class='streaming-provider'>
         <span class="material-symbols-outlined"><%= display_pay_model_icon(provider[:pay_model]) %></span>
-          <%= provider[:pay_model].titleize %> on <%= provider[:name] %>
+          <%= provider[:pay_model].titleize %> on <%= provider[:display_name] %>
         </a>
     <% end %>
   <% else %>
     <% streaming_service_providers.filter { |p| p[:pay_model] == 'free' }.each do |provider| %>
-      <a href="<%= provider[:url] %>" target="_blank" alt="<%= provider[:name] %>" title="<%= provider[:name] %>" class='streaming-provider'>
+      <a href="<%= provider[:url] %>" target="_blank" alt="<%= provider[:display_name] %>" title="<%= provider[:display_name] %>" class='streaming-provider'>
         <span class="material-symbols-outlined"><%= display_pay_model_icon(provider[:pay_model]) %></span>
-          <%= provider[:pay_model].titleize %> on <%= provider[:name] %>
+          <%= provider[:pay_model].titleize %> on <%= provider[:display_name] %>
         </a>
     <% end %>
   <% end %>

--- a/app/views/shared/_streaming_service_providers.html.erb
+++ b/app/views/shared/_streaming_service_providers.html.erb
@@ -5,4 +5,4 @@
     </a>
 <% end %>
 
-<p class='txt-sm avaliablity'>Availability data by <%= link_to 'JustWatch', 'https://www.justwatch.com', target: '_blank' %></p>
+<p class='txt-sm availability'>Availability data by <%= link_to 'JustWatch', 'https://www.justwatch.com', target: '_blank' %></p>

--- a/app/views/shared/_streaming_service_providers.html.erb
+++ b/app/views/shared/_streaming_service_providers.html.erb
@@ -1,7 +1,7 @@
 <% streaming_service_providers.each do |provider| %>
-  <a href="<%= provider[:url] %>" target="_blank" alt="<%= provider[:name] %>" title="<%= provider[:name] %>" class='streaming-provider'>
+  <a href="<%= provider[:url] %>" target="_blank" alt="<%= provider[:display_name] %>" title="<%= provider[:display_name] %>" class='streaming-provider'>
     <span class="material-symbols-outlined"><%= display_pay_model_icon(provider[:pay_model]) %></span>
-      <%= provider[:pay_model].titleize %> on <%= provider[:name] %>
+      <%= provider[:pay_model].titleize %> on <%= provider[:display_name] %>
     </a>
 <% end %>
 

--- a/spec/services/streaming_service_provider_data_service_spec.rb
+++ b/spec/services/streaming_service_provider_data_service_spec.rb
@@ -20,43 +20,36 @@ RSpec.describe StreamingServiceProviderDataService do
       it 'returns our default providers with a pay_model of "try"' do
         allow(Tmdb::Client).to receive(:request).and_return(nil)
 
-        results = StreamingServiceProviderDataService.get_providers(**movie_args)
-        aggregate_failures "all default providers appear with 'try'" do
-          expect(results.find {|r| r[:name] == 'Netflix'}[:pay_model] ).to eq('try')
-          expect(results.find {|r| r[:name] == 'Amazon Prime Video'}[:pay_model] ).to eq('try')
-          expect(results.find {|r| r[:name] == 'Amazon Video'}[:pay_model] ).to eq('try')
-          expect(results.find {|r| r[:name] == 'YouTube'}[:pay_model] ).to eq('try')
-          expect(results.find {|r| r[:name] == 'Vudu'}[:pay_model] ).to eq('try')
-        end
+        providers = StreamingServiceProviderDataService.get_providers(**movie_args)
+        try_pay_models = providers.select {|provider| provider[:pay_model] == 'try'}
+        expect(providers.length).to eq(try_pay_models.length)
       end
     end
 
     describe 'when the API does return results' do
+      let(:netflix_api_data) { {logo_path: "/5OAb2w.jpg", provider_id: 8, provider_name: "Netflix", display_priority: 26} }
+      let(:amazon_api_data) { {logo_path: "/5OAb2w.jpg", provider_id: 10, provider_name: "Amazon Video", display_priority: 26} }
+      let(:amazon_prime_api_data) { {logo_path: "/5OAb2w.jpg", provider_id: 9, provider_name: "Amazon Prime Video", display_priority: 25} }
+      let(:youtube_api_data) { {logo_path: "/xL9SUR.jpg", provider_id: 192, provider_name: "YouTube", display_priority: 51} }
+      let(:fandango_api_data) { {logo_path: "/peURlL.jpg", provider_id: 7, provider_name: "Fandango At Home", display_priority: 4} }
+
       describe 'but the results do not have free, flatrate, rent, or buy pay model options' do
         it 'returns our default providers with a pay_model of "try"' do
           response_data = {
             results: {
               US: {
                 ads:
-                  [{logo_path: "/5OAb2w.jpg", provider_id: 634, provider_name: "Netflix", display_priority: 26},
-                  {logo_path: "/eWp5Ld.jpg", provider_id: 43, provider_name: "Amazon Video", display_priority: 38},
-                  {logo_path: "/xL9SUR.jpg", provider_id: 358, provider_name: "YouTube", display_priority: 51}],
+                  [netflix_api_data, amazon_api_data, youtube_api_data],
                 subscribe:
-                  [{logo_path: "/peURlL.jpg", provider_id: 2, provider_name: "Vudu", display_priority: 4},
-                  {logo_path: "/peURlL.jpg", provider_id: 2, provider_name: "Amazon Prime Video", display_priority: 4}],
+                  [fandango_api_data, amazon_prime_api_data],
               }
             }
           }
           allow(Tmdb::Client).to receive(:request).and_return(response_data)
 
-          results = StreamingServiceProviderDataService.get_providers(**movie_args)
-          aggregate_failures "all default providers appear with 'try'" do
-            expect(results.find {|r| r[:name] == 'Netflix'}[:pay_model] ).to eq('try')
-            expect(results.find {|r| r[:name] == 'Amazon Prime Video'}[:pay_model] ).to eq('try')
-            expect(results.find {|r| r[:name] == 'Amazon Video'}[:pay_model] ).to eq('try')
-            expect(results.find {|r| r[:name] == 'YouTube'}[:pay_model] ).to eq('try')
-            expect(results.find {|r| r[:name] == 'Vudu'}[:pay_model] ).to eq('try')
-          end
+          providers = StreamingServiceProviderDataService.get_providers(**movie_args)
+          try_pay_models = providers.select {|provider| provider[:pay_model] == 'try'}
+          expect(providers.length).to eq(try_pay_models.length)
         end
       end
 
@@ -76,14 +69,9 @@ RSpec.describe StreamingServiceProviderDataService do
           }
           allow(Tmdb::Client).to receive(:request).and_return(response_data)
 
-          results = StreamingServiceProviderDataService.get_providers(**movie_args)
-          aggregate_failures "all default providers appear with 'try'" do
-            expect(results.find {|r| r[:name] == 'Netflix'}[:pay_model] ).to eq('try')
-            expect(results.find {|r| r[:name] == 'Amazon Prime Video'}[:pay_model] ).to eq('try')
-            expect(results.find {|r| r[:name] == 'Amazon Video'}[:pay_model] ).to eq('try')
-            expect(results.find {|r| r[:name] == 'YouTube'}[:pay_model] ).to eq('try')
-            expect(results.find {|r| r[:name] == 'Vudu'}[:pay_model] ).to eq('try')
-          end
+          providers = StreamingServiceProviderDataService.get_providers(**movie_args)
+          try_pay_models = providers.select {|provider| provider[:pay_model] == 'try'}
+          expect(providers.length).to eq(try_pay_models.length)
         end
       end
 
@@ -93,7 +81,7 @@ RSpec.describe StreamingServiceProviderDataService do
             results: {
               US: {
                 free:
-                  [{logo_path: "/5OAb2w.jpg", provider_id: 634, provider_name: "Netflix", display_priority: 26}]
+                  [netflix_api_data]
               }
             }
           }
@@ -101,7 +89,7 @@ RSpec.describe StreamingServiceProviderDataService do
           allow(Tmdb::Client).to receive(:request).and_return(response_data)
           results = StreamingServiceProviderDataService.get_providers(**movie_args)
 
-          expect(results.find {|r| r[:name] == 'Netflix'}[:pay_model] ).to eq('free')
+          expect(results.find {|r| r[:tmdb_provider_name] == netflix_api_data[:provider_name]}[:pay_model] ).to eq('free')
         end
       end
 
@@ -111,7 +99,7 @@ RSpec.describe StreamingServiceProviderDataService do
             results: {
               US: {
                 flatrate:
-                  [{logo_path: "/5OAb2w.jpg", provider_id: 634, provider_name: "Netflix", display_priority: 26}]
+                  [netflix_api_data]
               }
             }
           }
@@ -119,7 +107,7 @@ RSpec.describe StreamingServiceProviderDataService do
           allow(Tmdb::Client).to receive(:request).and_return(response_data)
           results = StreamingServiceProviderDataService.get_providers(**movie_args)
 
-          expect(results.find {|r| r[:name] == 'Netflix'}[:pay_model] ).to eq('free')
+          expect(results.find {|r| r[:tmdb_provider_name] == netflix_api_data[:provider_name]}[:pay_model] ).to eq('free')
         end
       end
 
@@ -129,14 +117,14 @@ RSpec.describe StreamingServiceProviderDataService do
             results: {
               US: {
                 rent:
-                  [{logo_path: "/peURlL.jpg", provider_id: 2, provider_name: "Netflix", display_priority: 4}]
+                  [amazon_api_data]
               }
             }
           }
           allow(Tmdb::Client).to receive(:request).and_return(response_data)
           results = StreamingServiceProviderDataService.get_providers(**movie_args)
 
-          expect(results.find {|r| r[:name] == 'Netflix'}[:pay_model] ).to eq('rent')
+          expect(results.find {|r| r[:tmdb_provider_name] == amazon_api_data[:provider_name]}[:pay_model] ).to eq('rent')
         end
       end
 
@@ -146,32 +134,32 @@ RSpec.describe StreamingServiceProviderDataService do
             results: {
               US: {
                 buy:
-                  [{logo_path: "/peURlL.jpg", provider_id: 2, provider_name: "Netflix", display_priority: 4}]
+                  [amazon_api_data]
               }
             }
           }
           allow(Tmdb::Client).to receive(:request).and_return(response_data)
           results = StreamingServiceProviderDataService.get_providers(**movie_args)
 
-          expect(results.find {|r| r[:name] == 'Netflix'}[:pay_model] ).to eq('buy')
+          expect(results.find {|r| r[:tmdb_provider_name] == amazon_api_data[:provider_name]}[:pay_model] ).to eq('buy')
         end
 
       end
 
-      describe 'when a preferred provider does not appears in the results for any pay model options' do
+      describe 'when a preferred provider does not appear in the results for any pay model options' do
         it 'returns this provider with a pay_model of "try"' do
           response_data = {
             results: {
               US: {
                 flatrate:
-                  [{logo_path: "/peURlL.jpg", provider_id: 2, provider_name: "Netflix", display_priority: 4}]
+                  [netflix_api_data]
               }
             }
           }
           allow(Tmdb::Client).to receive(:request).and_return(response_data)
           results = StreamingServiceProviderDataService.get_providers(**movie_args)
 
-          expect(results.find {|r| r[:name] == 'Vudu'}[:pay_model] ).to eq('try')
+          expect(results.find {|r| r[:tmdb_provider_name] == fandango_api_data[:provider_name]}[:pay_model] ).to eq('try')
         end
       end
 
@@ -181,16 +169,16 @@ RSpec.describe StreamingServiceProviderDataService do
             results: {
               US: {
                 flatrate:
-                  [{logo_path: "/peURlL.jpg", provider_id: 2, provider_name: "Vudu", display_priority: 4}],
+                  [fandango_api_data],
                 rent:
-                  [{logo_path: "/peURlL.jpg", provider_id: 2, provider_name: "Vudu", display_priority: 4}],
+                  [fandango_api_data],
               }
             }
           }
           allow(Tmdb::Client).to receive(:request).and_return(response_data)
           results = StreamingServiceProviderDataService.get_providers(**movie_args)
 
-          expect(results.find {|r| r[:name] == 'Vudu'}[:pay_model] ).to eq('free')
+          expect(results.find {|r| r[:tmdb_provider_name] == fandango_api_data[:provider_name]}[:pay_model] ).to eq('free')
         end
       end
 
@@ -200,16 +188,16 @@ RSpec.describe StreamingServiceProviderDataService do
               results: {
                 US: {
                   buy:
-                    [{logo_path: "/peURlL.jpg", provider_id: 2, provider_name: "Vudu", display_priority: 4}],
+                  [fandango_api_data],
                   rent:
-                    [{logo_path: "/peURlL.jpg", provider_id: 2, provider_name: "Vudu", display_priority: 4}],
+                  [fandango_api_data],
                 }
               }
             }
             allow(Tmdb::Client).to receive(:request).and_return(response_data)
             results = StreamingServiceProviderDataService.get_providers(**movie_args)
 
-            expect(results.find {|r| r[:name] == 'Vudu'}[:pay_model] ).to eq('rent')
+          expect(results.find {|r| r[:tmdb_provider_name] == fandango_api_data[:provider_name]}[:pay_model] ).to eq('rent')
         end
       end
 
@@ -219,15 +207,11 @@ RSpec.describe StreamingServiceProviderDataService do
             results: {
               US: {
                 flatrate:
-                  [{logo_path: "/5OAb2w.jpg", provider_id: 634, provider_name: "Netflix", display_priority: 26},
-                  {logo_path: "/eWp5Ld.jpg", provider_id: 43, provider_name: "Vudu", display_priority: 38}],
+                  [netflix_api_data, fandango_api_data],
                 buy:
-                  [{logo_path: "/peURlL.jpg", provider_id: 2, provider_name: "Vudu", display_priority: 4},
-                  {logo_path: "/5NyLm4.jpg", provider_id: 10, provider_name: "Amazon Video", display_priority: 12},
-                  {logo_path: "/oIkQkE.jpg", provider_id: 192, provider_name: "YouTube", display_priority: 14}],
+                  [fandango_api_data, amazon_api_data, youtube_api_data],
                 rent:
-                  [{logo_path: "/peURlL.jpg", provider_id: 2, provider_name: "Vudu", display_priority: 4},
-                  {logo_path: "/5NyLm4.jpg", provider_id: 10, provider_name: "Amazon Video", display_priority: 12}],
+                  [fandango_api_data,  amazon_api_data],
               }
             }
           }
@@ -235,11 +219,11 @@ RSpec.describe StreamingServiceProviderDataService do
           results = StreamingServiceProviderDataService.get_providers(**movie_args)
 
           aggregate_failures "expected pay_model levels per provider" do
-            expect(results.find {|r| r[:name] == 'Netflix'}[:pay_model] ).to eq('free')
-            expect(results.find {|r| r[:name] == 'Amazon Prime Video'}[:pay_model] ).to eq('try')
-            expect(results.find {|r| r[:name] == 'Amazon Video'}[:pay_model] ).to eq('rent')
-            expect(results.find {|r| r[:name] == 'YouTube'}[:pay_model] ).to eq('buy')
-            expect(results.find {|r| r[:name] == 'Vudu'}[:pay_model] ).to eq('free')
+            expect(results.find {|r| r[:tmdb_provider_name] == netflix_api_data[:provider_name]}[:pay_model] ).to eq('free')
+            expect(results.find {|r| r[:tmdb_provider_name] == amazon_prime_api_data[:provider_name]}[:pay_model] ).to eq('try')
+            expect(results.find {|r| r[:tmdb_provider_name] == amazon_api_data[:provider_name]}[:pay_model] ).to eq('rent')
+            expect(results.find {|r| r[:tmdb_provider_name] == youtube_api_data[:provider_name]}[:pay_model] ).to eq('buy')
+            expect(results.find {|r| r[:tmdb_provider_name] == fandango_api_data[:provider_name]}[:pay_model] ).to eq('free')
           end
         end
       end
@@ -250,11 +234,11 @@ RSpec.describe StreamingServiceProviderDataService do
             results: {
               US: {
                 flatrate:
-                  [{logo_path: "/eWp5Ld.jpg", provider_id: 43, provider_name: "Starz", display_priority: 38}],
+                  [{logo_path: "/eWp5Ld.jpg", provider_id: 1, provider_name: "Foo", display_priority: 38}],
                 buy:
-                  [{logo_path: "/eWp5Ld.jpg", provider_id: 43, provider_name: "Google Play Movies", display_priority: 38}],
+                  [{logo_path: "/eWp5Ld.jpg", provider_id: 2, provider_name: "Bar", display_priority: 38}],
                 rent:
-                  [{logo_path: "/eWp5Ld.jpg", provider_id: 43, provider_name: "AMC on Demand", display_priority: 38}]
+                  [{logo_path: "/eWp5Ld.jpg", provider_id: 3, provider_name: "Baz", display_priority: 38}]
               }
             }
           }
@@ -262,51 +246,48 @@ RSpec.describe StreamingServiceProviderDataService do
 
           results = StreamingServiceProviderDataService.get_providers(**movie_args)
           aggregate_failures "expecting to not find any of these non-preferred providers" do
-            expect(results.find {|r| r[:name] == 'Starz'}).to be(nil)
-            expect(results.find {|r| r[:name] == 'Google Play Movies'}).to be(nil)
-            expect(results.find {|r| r[:name] == 'AMC on Demand'}).to be(nil)
+            expect(results.find {|r| r[:tmdb_provider_name] == 'Foo'}).to be(nil)
+            expect(results.find {|r| r[:tmdb_provider_name] == 'Bar'}).to be(nil)
+            expect(results.find {|r| r[:tmdb_provider_name] == 'Baz'}).to be(nil)
           end
         end
       end
-    end
 
-    describe 'when searching for providers for a TV series' do
-      let(:tv_args) do
-        {
-          tmdb_id: 'foo',
-          title: 'foo',
-          media_type: 'tv',
-          media_format: 'episodes'
-        }
-      end
-
-      it "returns each provider with preferring free, then rent, then buy, and then 'try' for ones that weren't found" do
-        response_data = {
-          results: {
-            US: {
-              free:
-                [{logo_path: "/eWp5Ld.jpg", provider_id: 43, provider_name: "Vudu", display_priority: 38}],
-              flatrate:
-                [{logo_path: "/5OAb2w.jpg", provider_id: 634, provider_name: "Netflix", display_priority: 26}],
-              buy:
-                [{logo_path: "/peURlL.jpg", provider_id: 2, provider_name: "Vudu", display_priority: 4},
-                {logo_path: "/5NyLm4.jpg", provider_id: 10, provider_name: "Amazon Video", display_priority: 12},
-                {logo_path: "/oIkQkE.jpg", provider_id: 192, provider_name: "YouTube", display_priority: 14}],
-              rent:
-                [{logo_path: "/peURlL.jpg", provider_id: 2, provider_name: "Vudu", display_priority: 4},
-                {logo_path: "/5NyLm4.jpg", provider_id: 10, provider_name: "Amazon Video", display_priority: 12}],
+      describe 'when searching for providers for a TV series' do
+        let(:tv_args) do
+          {
+            tmdb_id: 'foo',
+            title: 'foo',
+            media_type: 'tv',
+            media_format: 'episodes'
+          }
+        end
+  
+        it "returns each provider with preferring free, then rent, then buy, and then 'try' for ones that weren't found" do
+          response_data = {
+            results: {
+              US: {
+                free:
+                  [fandango_api_data],
+                flatrate:
+                  [netflix_api_data],
+                buy:
+                  [fandango_api_data, amazon_api_data, youtube_api_data],
+                rent:
+                  [fandango_api_data, amazon_api_data],
+              }
             }
           }
-        }
-        allow(Tmdb::Client).to receive(:request).and_return(response_data)
-        results = StreamingServiceProviderDataService.get_providers(**tv_args)
-
-        aggregate_failures "expected pay_model levels per provider" do
-          expect(results.find {|r| r[:name] == 'Netflix'}[:pay_model] ).to eq('free')
-          expect(results.find {|r| r[:name] == 'Amazon Prime Video'}[:pay_model] ).to eq('try')
-          expect(results.find {|r| r[:name] == 'Amazon Video'}[:pay_model] ).to eq('rent')
-          expect(results.find {|r| r[:name] == 'YouTube'}[:pay_model] ).to eq('buy')
-          expect(results.find {|r| r[:name] == 'Vudu'}[:pay_model] ).to eq('free')
+          allow(Tmdb::Client).to receive(:request).and_return(response_data)
+          results = StreamingServiceProviderDataService.get_providers(**tv_args)
+  
+          aggregate_failures "expected pay_model levels per provider" do
+            expect(results.find {|r| r[:tmdb_provider_name] == netflix_api_data[:provider_name]}[:pay_model] ).to eq('free')
+            expect(results.find {|r| r[:tmdb_provider_name] == amazon_prime_api_data[:provider_name]}[:pay_model] ).to eq('try')
+            expect(results.find {|r| r[:tmdb_provider_name] == amazon_api_data[:provider_name]}[:pay_model] ).to eq('rent')
+            expect(results.find {|r| r[:tmdb_provider_name] == youtube_api_data[:provider_name]}[:pay_model] ).to eq('buy')
+            expect(results.find {|r| r[:tmdb_provider_name] == fandango_api_data[:provider_name]}[:pay_model] ).to eq('free')
+          end
         end
       end
     end


### PR DESCRIPTION
## Problems Solved
* Since Hooplah is not casting properly, I found a new provider (Kanopy) and included it in our list of providers
* We have Peacock Premium (and maybe Premium Plus) for a brief moment, so I'm including it in the list.
* VUDU has changed. It has a free-with-ads pay model now, so I'm commenting it out
* VUDU free has rolled into Fandango, so that data is updated
* I'm using api ids to match services instead of name matching now
* I've incorporated a `display_name` so we're not beholden to the API `provider_name`

## Things Learned
* I just started using the VS code plugin called "Code Spell Checker" and that caught a typo for us
* It would be neat if TMDB had an API endpoint for a service providers index, but it does not
* It would also be neat if it were easier to add/remove streaming providers, but at least right now we can comment them out of the data hash
