### PR TITLE
Fix broken streaming service provider display logic 🤦 

### DIFF
--- a/app/views/shared/_streaming_service_providers.html.erb
+++ b/app/views/shared/_streaming_service_providers.html.erb
@@ -1,5 +1,5 @@
 <div class="mt-5 streaming-service-providers-container">
-  <% if !StreamingServiceProvider.free.any? %>
+  <% if StreamingServiceProvider.free.any? %>
     <div class="mb-5">
       <span class="material-symbols-outlined">emoji_emotions</span> Free: 
       <span class="streaming-providers-list">


### PR DESCRIPTION
## Problems Solved
* When I was demoing the free vs not free feature, I accidentally left the reverse logic in the view.
* This PR removes that errant `!`


