### PR TITLE
Clean up actor tv credits

### DIFF
--- a/app/views/shared/_tv_series_profile_content.html.erb
+++ b/app/views/shared/_tv_series_profile_content.html.erb
@@ -39,7 +39,7 @@
           <div class="headshot-container">
             <%= headshot_for(actor) %>
             <div class="name-block">
-              <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}")) %></p>
+              <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_more_path(actor_id: actor.actor_id) %></p>
               <p>as <%= truncate(actor.character_name, length: 18, escape: false) %></p>
             </div>
           </div>

--- a/app/views/tmdb/_tv_credits.html.erb
+++ b/app/views/tmdb/_tv_credits.html.erb
@@ -1,9 +1,17 @@
 <h3>TV Credits (<%= tv_credits.actor.size %>)</h3>
 <ul>
   <% tv_credits.actor.each do |credit| %>
-    <li><%= link_to "#{credit.show_name}", tv_series_path(show_id: credit.show_id, actor_id: actor_id) %>
-    <%= "| as #{credit.character}" if credit.character.present? %> |
-    <%= link_to " Appearance Details", actor_credit_path(actor_id: actor_id, credit_id: credit.credit_id,
-    show_name: "#{credit.show_name}"), id: "appearance_details_#{credit.show_name.downcase}" %></li>
+    <li>
+      <%= link_to "#{credit.show_name}", tv_series_path(show_id: credit.show_id, actor_id: actor_id) %> | 
+      <% if credit.character.present? %>
+        as <%= link_to credit.character, 
+            actor_credit_path(actor_id: actor_id, credit_id: credit.credit_id, show_name: "#{credit.show_name}"), 
+            id: "appearance_details_#{credit.show_name.downcase}" %>
+      <% else %>
+        <%= link_to "episodes", 
+            actor_credit_path(actor_id: actor_id, credit_id: credit.credit_id, show_name: "#{credit.show_name}"), 
+            id: "appearance_details_#{credit.show_name.downcase}" %>
+      <% end %>
+    </li>
   <% end %>
 </ul>

--- a/app/views/tmdb/actor_credit.html.erb
+++ b/app/views/tmdb/actor_credit.html.erb
@@ -38,7 +38,7 @@
               <ul>
                 <% episode.guest_stars.each do |guest| %>
                   <li>
-                    <%= link_to "#{guest.name}", actor_search_path(actor: "#{guest.name}") %>
+                    <%= link_to "#{guest.name}", actor_more_path(actor)id: guest.actor_id) %>
                     <%= "as #{guest.character_name}" if guest.character_name.present? %>
                   </li>
                 <% end %>

--- a/app/views/tmdb/actor_credit.html.erb
+++ b/app/views/tmdb/actor_credit.html.erb
@@ -1,7 +1,7 @@
 <h1>
-  Episodes with <%= link_to "#{@credit.actor_name}", actor_more_path(actor_id: @credit.actor_id) %>
+  Episodes with <%= link_to @credit.actor_name, actor_more_path(actor_id: @credit.actor_id) %>
   <%= "as #{@credit.character}" if @credit.character.present? %>
-  on <%= link_to "#{@credit.show_name}", tv_series_path(show_id: @credit.show_id) %>
+  on <%= link_to @credit.show_name, tv_series_path(show_id: @credit.show_id) %>
 </h1>
 <%= link_to "Actor Profile", actor_more_path(actor_id: @credit.actor_id), class: 'btn' %>
 
@@ -38,7 +38,7 @@
               <ul>
                 <% episode.guest_stars.each do |guest| %>
                   <li>
-                    <%= link_to "#{guest.name}", actor_more_path(actor)id: guest.actor_id) %>
+                    <%= link_to guest.name, actor_more_path(actor_id: guest.actor_id) %>
                     <%= "as #{guest.character_name}" if guest.character_name.present? %>
                   </li>
                 <% end %>

--- a/app/views/tmdb/tv_episode.html.erb
+++ b/app/views/tmdb/tv_episode.html.erb
@@ -17,7 +17,7 @@
   <div class="headshot-container">
   <%= headshot_for(actor) %>
     <div class="name-block">
-      <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
+      <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_more_path(actor_id: actor.actor_id)  %></p>
       <p>as <%= truncate(actor.character_name, length: 18, escape: false) %><p>
     </div>
   </div>
@@ -27,7 +27,7 @@
     <div class="headshot-container">
     <%= headshot_for(actor) %>
       <div class="name-block">
-        <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
+        <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_more_path(actor_id: actor.actor_id)  %></p>
         <p>as <%= truncate(actor.character_name, length: 18, escape: false) %><p>
       </div>
     </div>

--- a/app/views/tmdb/tv_season.html.erb
+++ b/app/views/tmdb/tv_season.html.erb
@@ -21,7 +21,7 @@
           <div class="headshot-container">
             <%= headshot_for(actor) %>
             <div class="name-block">
-              <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_search_path(actor: I18n.transliterate("#{actor.name}"))  %></p>
+              <p class="actor"><%= link_to "#{truncate(actor.name, length: 18, escape: false)}", actor_more_path(actor_id: actor.actor_id)  %></p>
               <p>as <%= truncate(actor.character_name, length: 18, escape: false) %><p>
             </div>
           </div>

--- a/app/views/tmdb/tv_season.html.erb
+++ b/app/views/tmdb/tv_season.html.erb
@@ -63,9 +63,13 @@
               <% episode.guest_stars.each do |guest| %>
                 <li>
                   <%= link_to guest.name, actor_more_path(actor_id: guest.actor_id) %>
-                  <%= "as #{guest.character_name}" if guest.character_name.present? %>
-                  | <%= link_to "Episodes", actor_credit_path(actor_id: guest.actor_id, credit_id: guest.credit_id,
+                  <% if guest.character_name.present? %>
+                    as <%= link_to guest.character_name, actor_credit_path(actor_id: guest.actor_id, credit_id: guest.credit_id,
     show_name: "#{@series.show_name}"), id: "appearance_details_#{@series.show_name.downcase}" %>
+                  <% else %>
+                    | <%= link_to "episodes", actor_credit_path(actor_id: guest.actor_id, credit_id: guest.credit_id,
+    show_name: "#{@series.show_name}"), id: "appearance_details_#{@series.show_name.downcase}" %>
+                  <% end %>
                 </li>
               <% end %>
             </ul>

--- a/spec/features/tmdb_feature_spec.rb
+++ b/spec/features/tmdb_feature_spec.rb
@@ -390,7 +390,7 @@ RSpec.feature "TMDB feature spec", type: :feature, feature: :true do
           click_link_or_button "bio_and_credits_link_actor_search"
         end
         VCR.use_cassette("actor_tv_credit") do
-          click_link "Appearance Details", match: :first
+          click_link "episodes", match: :first
         end
         expect(current_url).to eq(actor_credit_url(actor_id: 884, credit_id: "56ad478dc3a3681c34006885", show_name: "Horace and Pete"))
         expect(page).to have_content("Horace")


### PR DESCRIPTION
## Related Issues & PRs
Related to #380

## Problems Solved
* Streamlines the tv "appearance details" link on an actor bio by using the character name as a link to the character appearances
* Replaces the link to actor credits from `actor_search_path` to `actor_more_path`, which is the bio page. Which partially closes #380.
* I was very tempted to also make our actor search result redirect to the bio page, but I broke it out of #380 and moved it to its own issue #459.

## Screenshots
My goal here for these visual changes is to reduce visual clutter and annoying line wraps when trying to visually scan a list of TV credits on my phone. This change makes each line shorter and reduces the need for a line wrap.
 
|Before | After |
|----|-----|
|<img width="430" alt="Screenshot 2025-02-23 at 9 21 15 AM" src="https://github.com/user-attachments/assets/5d3422d0-3f8f-428d-8537-f1c427538202" /> | <img width="297" alt="Screenshot 2025-02-23 at 9 21 01 AM" src="https://github.com/user-attachments/assets/64d2fc5d-87e9-4c29-87a2-f4c1edff97d2" /> | 

Sometimes an actor is on a show but does not have a character name. For example, Jason Sudeikis was on SNL and doesn't have an individual credit for each skit character he plays. In those cases, we just render the word "Episodes" -- much like the original behavior with the phrase "Appearance Details".

### Due Diligence Checks
- [ ] wrote new specs for this work
- [x] ran non-feature specs locally
- [x] tested it in the browser locally
- [x] deployed branch to prod and browser tested it (before merging to `master`)

