### PR TITLE
Add main cast content to episode credits page

### DIFF
--- a/app/entities/tv_actor_credit.rb
+++ b/app/entities/tv_actor_credit.rb
@@ -18,7 +18,7 @@ class TVActorCredit
   def self.parse_record(record)
     seasons = TVCreditSeason.parse_records(record[:media][:seasons]).presence if record[:media][:seasons].present?
     episodes = TVEpisode.parse_records(record[:media][:episodes]).presence if record[:media][:episodes].present?
-    episodes_by_number = episodes.sort_by { |e|e.episode_number } if episodes.present?
+    episodes_by_number = episodes.present? ? episodes.sort_by { |e|e.episode_number } : []
     new(
       actor_name: record[:person][:name],
       actor_id: record[:person][:id],
@@ -30,5 +30,9 @@ class TVActorCredit
       show_name: record[:media][:name],
       seasons: seasons
     )
+  end
+
+  def in_main_cast?
+    @character.present? && @episodes.empty?
   end
 end

--- a/app/entities/tv_actor_credit.rb
+++ b/app/entities/tv_actor_credit.rb
@@ -16,7 +16,7 @@ class TVActorCredit
   end
 
   def self.parse_record(record)
-    seasons = TVCreditSeason.parse_records(record[:media][:seasons]).presence if record[:media][:seasons].present?
+    seasons = TVCreditSeason.parse_records(record[:media][:seasons]).sort_by {|s| s.name}
     episodes = TVEpisode.parse_records(record[:media][:episodes]).presence if record[:media][:episodes].present?
     episodes_by_number = episodes.present? ? episodes.sort_by { |e|e.episode_number } : []
     new(
@@ -33,6 +33,15 @@ class TVActorCredit
   end
 
   def in_main_cast?
-    @character.present? && @episodes.empty?
+    # If an actor's character doesn't have a name, then they are not in the main cast.
+    return false if @character.empty?
+    # When an actor's episodes array is empty and the character has a name, they are in the main cast.
+    return true if @episodes.empty?
+    
+    # There are cases when an actor appeared as a guest before or after being in the main cast. 
+    # We reserve making this API call only for that condition. Note the actor must be in the final
+    # series cast data, so if they were replaced by another actor, this will return false.
+    series_data = TVSeriesDataService.get_tv_series_data(@show_id)
+    series_data.actors.map(&:actor_id).include?(@actor_id)
   end
 end

--- a/app/entities/tv_credits.rb
+++ b/app/entities/tv_credits.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class TVCredits
-  attr_accessor :credit_id, :department, :job, :show_id, :show_name, :poster_path, :character, :first_air_date
+  attr_accessor :credit_id, :department, :job, :show_id, :show_name, :poster_path, :character, :episodes, :seasons, :first_air_date
 
-  def initialize(credit_id:, department:, job:, show_id:, show_name:, poster_path:, character:, first_air_date:)
+  def initialize(credit_id:, department:, job:, show_id:, show_name:, poster_path:, character:, episodes:, seasons:, first_air_date:)
     @credit_id = credit_id
     @department = department
     @job = job
@@ -11,6 +11,8 @@ class TVCredits
     @show_name = show_name
     @poster_path = poster_path
     @character = character
+    @episodes = episodes
+    @seasons = seasons
     @first_air_date = first_air_date
   end
 
@@ -25,6 +27,8 @@ class TVCredits
           show_name: result[:name],
           poster_path: result[:poster_path],
           character: result[:character],
+          episodes: result[:episodes],
+          seasons: result[:seasons],
           first_air_date: format_first_air_date(result[:first_air_date])
         )
       end.sort_by { |credit| credit.first_air_date }.reverse

--- a/app/views/tmdb/actor_credit.html.erb
+++ b/app/views/tmdb/actor_credit.html.erb
@@ -3,7 +3,17 @@
   <%= "as #{@credit.character}" if @credit.character.present? %>
   on <%= link_to @credit.show_name, tv_series_path(show_id: @credit.show_id) %>
 </h1>
-<%= link_to "Actor Profile", actor_more_path(actor_id: @credit.actor_id), class: 'btn' %>
+<p><%= link_to "Actor Profile", actor_more_path(actor_id: @credit.actor_id), class: 'btn' %></p>
+<br>
+
+<% if @credit.in_main_cast? %>
+  <p class="mt-10"><%= @credit.actor_name %> was in the main cast as <%= @credit.character %> for <%= @credit.seasons.size %> seasons.</p>
+  <ul>
+    <% @credit.seasons.sort_by {|season| season.season_number}.each do |season| %>
+      <li><%= link_to season.name, tv_season_path(show_id: @credit.show_id, season_number: season.season_number) %></li>
+    <% end %>
+  </ul>
+<% end %>
 
 <% if @credit.episodes.present? %>
   <% @credit.episodes.group_by {|c| c.season_number}.each do |season| %>

--- a/spec/entities/tv_actor_credit_spec.rb
+++ b/spec/entities/tv_actor_credit_spec.rb
@@ -3,36 +3,47 @@
 require 'rails_helper'
 
 RSpec.describe TVActorCredit, type: :model do
-  describe "in_main_cast?" do
-    context "when there is no character and there are episodes" do
-      let(:tv_actor_credit) { build(:tv_actor_credit, :with_episodes, character: "") }
-      
-      it "returns false" do
-        expect(tv_actor_credit.in_main_cast?).to eq(false)
-      end
-    end
+  let(:actor_id) { 1234 }
 
-    context "when there is no character and there are no episodes" do
-      let(:tv_actor_credit) { build(:tv_actor_credit, episodes: [], character: "") }
+  describe "in_main_cast?" do
+    context "when there is a character but there are no episodes" do
+      let(:tv_actor_credit) { build(:tv_actor_credit, episodes: [], actor_id: actor_id, character: "foo") }
       
-      it "returns false" do
-        expect(tv_actor_credit.in_main_cast?).to eq(false)
+      it "returns true" do
+        expect(tv_actor_credit.in_main_cast?).to eq(true)
       end
     end
 
     context "when there is a character and there are episodes" do
-      let(:tv_actor_credit) { build(:tv_actor_credit, :with_episodes, character: "foo") }
+      let(:tv_actor_credit) { build(:tv_actor_credit, :with_episodes, actor_id: actor_id, character: "foo") }
       
-      it "returns false" do
-        expect(tv_actor_credit.in_main_cast?).to eq(false)
+      context "and the person appears in the series cast credits" do
+        before { allow(TVSeriesDataService).to receive(:get_tv_series_data).and_return(series_data) }
+        
+        let(:series_data) { OpenStruct.new( actors: [OpenStruct.new(actor_id: actor_id)]) }
+       
+        it "returns true" do
+          expect(tv_actor_credit.in_main_cast?).to eq(true)
+        end
+      end
+
+      context "and the person does not appear in the series cast credits" do
+        before { allow(TVSeriesDataService).to receive(:get_tv_series_data).and_return(series_data) }
+        
+        let(:series_data) { OpenStruct.new( actors: [OpenStruct.new(actor_id: other_actor_id)]) }
+        let(:other_actor_id) { 5678 }
+       
+        it "returns false" do
+          expect(tv_actor_credit.in_main_cast?).to eq(false)
+        end
       end
     end
 
-    context "when there is a character but there are no episodes" do
-      let(:tv_actor_credit) { build(:tv_actor_credit, episodes: [], character: "foo") }
+    context "when there is no character" do
+      let(:tv_actor_credit) { build(:tv_actor_credit, :with_episodes, actor_id: actor_id, character: "") }
       
-      it "returns true" do
-        expect(tv_actor_credit.in_main_cast?).to eq(true)
+      it "returns false" do
+        expect(tv_actor_credit.in_main_cast?).to eq(false)
       end
     end
   end

--- a/spec/entities/tv_actor_credit_spec.rb
+++ b/spec/entities/tv_actor_credit_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TVActorCredit, type: :model do
+  describe "in_main_cast?" do
+    context "when there is no character and there are episodes" do
+      let(:tv_actor_credit) { build(:tv_actor_credit, :with_episodes, character: "") }
+      
+      it "returns false" do
+        expect(tv_actor_credit.in_main_cast?).to eq(false)
+      end
+    end
+
+    context "when there is no character and there are no episodes" do
+      let(:tv_actor_credit) { build(:tv_actor_credit, episodes: [], character: "") }
+      
+      it "returns false" do
+        expect(tv_actor_credit.in_main_cast?).to eq(false)
+      end
+    end
+
+    context "when there is a character and there are episodes" do
+      let(:tv_actor_credit) { build(:tv_actor_credit, :with_episodes, character: "foo") }
+      
+      it "returns false" do
+        expect(tv_actor_credit.in_main_cast?).to eq(false)
+      end
+    end
+
+    context "when there is a character but there are no episodes" do
+      let(:tv_actor_credit) { build(:tv_actor_credit, episodes: [], character: "foo") }
+      
+      it "returns true" do
+        expect(tv_actor_credit.in_main_cast?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/factories/tv_actor_credits.rb
+++ b/spec/factories/tv_actor_credits.rb
@@ -1,0 +1,75 @@
+FactoryBot.define do
+  factory :tv_actor_credit do
+    sequence(:actor_id) { |n| n + 20 }
+    sequence(:actor_name) { |n| "actor_name #{n}" }
+    sequence(:character) { |n| "character #{n}" }
+    sequence(:known_for) { |n| "known_for #{n}" }
+    sequence(:profile_path) { |n| "profile_path_#{n}" }
+    sequence(:show_id) { |n| n + 10 }
+    sequence(:show_name) { |n| "show #{n}" }
+    episodes do
+      [{:id=>37065,
+      :name=>"The Naked Now",
+      :overview=>
+       "Stardate: 41209.2. The crew of the Enterprise are infected with a virus contracted by the away team while they were investigating  the mysterious deaths of the entire crew of the Starship Tsilkovsky.",
+      :media_type=>"tv_episode",
+      :vote_average=>6.4,
+      :vote_count=>57,
+      :air_date=>"1987-10-05",
+      :episode_number=>2,
+      :episode_type=>"standard",
+      :production_code=>"40271-103",
+      :runtime=>46,
+      :season_number=>1,
+      :show_id=>655,
+      :still_path=>"/ev3d6SQf7tPoOZ0bE778LlrPumJ.jpg"}]
+    end
+    seasons do
+      [{:id=>1989,
+      :name=>"Season 1",
+      :overview=>
+       "Picking up decades after the original Star Trek series, season one begins the intergalactic adventures of Capt. Jean-Luc Picard and his loyal crew aboard the all-new USS Enterprise NCC-1701D, as they explore new worlds.",
+      :profile_path=>"/cqfhZiCBqryQjo7s0cqZJOssE7d.jpg",
+      :media_type=>"tv_season",
+      :vote_average=>6.5,
+      :air_date=>"1987-09-28",
+      :season_number=>1,
+      :show_id=>655,
+      :episode_count=>25}]
+    end
+
+    initialize_with do
+      new(
+        actor_id: actor_id,
+        actor_name: actor_name,
+        character: character,
+        known_for: known_for,
+        profile_path: profile_path,
+        show_id: show_id,
+        show_name: show_name,
+        episodes: episodes,
+        seasons: seasons,
+      )
+    end
+
+    trait :with_episodes do 
+      episodes do
+        [{:id=>37065,
+        :name=>"The Naked Now",
+        :overview=>
+        "Stardate: 41209.2. The crew of the Enterprise are infected with a virus contracted by the away team while they were investigating  the mysterious deaths of the entire crew of the Starship Tsilkovsky.",
+        :media_type=>"tv_episode",
+        :vote_average=>6.4,
+        :vote_count=>57,
+        :air_date=>"1987-10-05",
+        :episode_number=>2,
+        :episode_type=>"standard",
+        :production_code=>"40271-103",
+        :runtime=>46,
+        :season_number=>1,
+        :show_id=>655,
+        :still_path=>"/ev3d6SQf7tPoOZ0bE778LlrPumJ.jpg"}]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problems Solved
**TL;DR:** it's imperfect, but an improvement for most cases.

It is very weird to go to the TV episode credit page for a main cast actor and see nothing.
BEFORE:
<img width="1051" alt="Screenshot 2025-02-26 at 10 44 39 AM" src="https://github.com/user-attachments/assets/888bcfc0-c2c1-4bdf-8a6d-39e701020331" />

This is because of the way TMDB handles its episode data for these characters. If we were storing all of this data in our own db, it would be easy to query, but this would be a lot of API hits to get everything for this page. So I'm making this small improvement where we acknowledge that the person was in the main cast for the seasons that they were.
AFTER:
<img width="944" alt="Screenshot 2025-02-26 at 10 44 12 AM" src="https://github.com/user-attachments/assets/cc10340b-9910-4a56-ae93-337870189a39" />

The Natalie (Monk) situation is a little weird. Even though this character was introduced halfway through season 3, she's not credited as main cast until season 4. The end result is that we were only seeing a handful of episodes on this credits page when we know she's in every episode from season 4 through 8. I was able to work around this weirdness by comparing the actor's id with the list of ids in the series cast with a subsequent API call. 
<img width="967" alt="Screenshot 2025-03-03 at 10 43 29 AM" src="https://github.com/user-attachments/assets/ac500987-2dc3-4ac0-bb35-eede4cf29e94" />

But it gets harder when we have a Sharona (Monk) or Kes (Voyager) situation. Both Sharona and Kes are replaced as main cast in roughly season 3 of their respective tv shows, so they don't appear in the TMDB series main cast data. This means, we're only seeing the credits for when they were non-cast on the show. For example, Sharona was in the main cast on Monk for seasons 1, 2, and half of 3. Then she appeared once in season 8. The credits only show those overlap seasons (3 and 8). Similarly, Kes was main cast for seasons 1-3 and partial season 4. But we're only seeing the overlap episodes in season 4 and the single episode in season 6 when she came back as a guest.

<img width="927" alt="Screenshot 2025-02-26 at 10 47 37 AM" src="https://github.com/user-attachments/assets/1b6949d4-7c8b-4233-b143-7f67c2a73789" />
<img width="890" alt="Screenshot 2025-03-03 at 10 51 43 AM" src="https://github.com/user-attachments/assets/02029aae-430d-44cf-b184-9cbe81c625ff" />



I may be able to resolve that with a lot of fancier API calls, but I'm not sure we care enough to do that. For that reason, I'm choosing not to solve for that particular situation in this PR.

## Data Patterns
First of all, the data is imperfect, so I made the best assumptions I could with what I was seeing. In order to make this `is_main_cast?` logic, I looked at data for different character types across a few shows. Here is a sample of the data for the Monk characters:
```
Sharona has 
  episodes: select from seasons 3 and 8
  seasons: Specials, 1, 2, 8
Natalie has 
  episodes: select from season 3
  seasons: 4, 5, 6, 7, 8
Randy has
  episodes: []
  seasons: Specials, 1, 2, 3, 4, 5, 6, 7, 8
Stottlemeyer has
  episodes: []
  seasons: Specials, 1, 2, 3, 4, 5, 6, 7, 8
Guest star 1 has
  episodes: one from season 3
  seasons: 3
Guest star 2 has
  episodes: one from season 3
  seasons: []
```

## Merge Checklist
- [x] I have written specs for this work
- [x] I ran specs locally with `bundle exec rspec spec --tag ~@feature`
- [x] I have browser tested this locally for different scenarios
- [ ] I have deployed the branch to production for testing 

