### PR TITLE
471: Revert "Add indexes to listings table"

### DIFF
--- a/db/migrate/20250302154214_revert_listing_indexes.rb
+++ b/db/migrate/20250302154214_revert_listing_indexes.rb
@@ -1,0 +1,13 @@
+class RevertListingIndexes < ActiveRecord::Migration[7.1]
+  def up
+    remove_index :listings, [:movie_id, :list_id] if index_exists?(:listings, [:movie_id, :list_id])
+    add_index :listings, :movie_id if !index_exists?(:listings, :movie_id)
+    add_index :listings, :list_id if !index_exists?(:listings, :list_id)
+  end
+
+  def down
+    add_index :listings, [:movie_id, :list_id], unique: true if !index_exists?(:listings, [:movie_id, :list_id])
+    remove_index :listings, :movie_id if index_exists?(:listings, :movie_id)
+    remove_index :listings, :list_id if index_exists?(:listings, :list_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_01_135740) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_02_154214) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,7 +43,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_01_135740) do
     t.datetime "updated_at", precision: nil, null: false
     t.integer "user_id"
     t.integer "priority"
-    t.index ["movie_id", "list_id"], name: "index_listings_on_movie_id_and_list_id", unique: true
+    t.index ["list_id"], name: "index_listings_on_list_id"
+    t.index ["movie_id"], name: "index_listings_on_movie_id"
   end
 
   create_table "lists", force: :cascade do |t|


### PR DESCRIPTION
## Related Issues & PRs
Closes #471

## Problems Solved
* "reverts" the migrations added by adding new migration to do the opposite to get them back to original state

## Screenshots
[screenshots here]

## Things Learned
*
