### PR TITLE
Add streaming providers

### DIFF
--- a/app/entities/streaming_service_provider.rb
+++ b/app/entities/streaming_service_provider.rb
@@ -210,6 +210,14 @@ class StreamingServiceProvider < ActiveHash::Base
       search_url: "https://www.peacocktv.com/watch/search?q="
     },
     {
+      id: "a038107b-d7bd-4ff9-bcd2-6fdec3028ea4",
+      display_name: 'Philo',
+      tmdb_provider_name: "Philo",
+      tmdb_provider_id: 2383,
+      tmdb_logo_path:"/ptmbGSttkyzawLbxx9MElmxKuVo.jpg",
+      search_url: "https://www.philo.com"
+    },
+    {
       id: "bbf23f2b-86e3-4635-bbba-a26ce48b14dc",
       display_name: 'Plex',
       tmdb_provider_name: "Plex",

--- a/app/entities/streaming_service_provider.rb
+++ b/app/entities/streaming_service_provider.rb
@@ -162,6 +162,22 @@ class StreamingServiceProvider < ActiveHash::Base
       search_url: "https://www.paramountplus.com/?="
     },
     {
+      id: "4309fbac-3610-420d-9298-5d4298b3d44c",
+      display_name: "Paramount+ Essential",
+      tmdb_provider_name: "Paramount Plus Essential",
+      tmdb_provider_id: 2616,
+      tmdb_logo_path: "/5wym1C0jAvJeGirPdgVpcW0CCuy.jpg",
+      search_url: "https://www.paramountplus.com/?="
+    },
+    {
+      id: "d0c601fc-a36b-4836-bdd3-ec82a69555b2",
+      display_name: "Paramount+ Premium",
+      tmdb_provider_name: "Paramount Plus Premium",
+      tmdb_provider_id: 2303,
+      tmdb_logo_path: "/fts6X10Jn4QT0X6ac3udKEn2tJA.jpg",
+      search_url: "https://www.paramountplus.com/?="
+    },
+    {
       id: "d73f7843-408d-444f-a5d9-5efa4674b7ae",
       display_name: "Paramount+Apple",
       tmdb_provider_name: "Paramount Plus Apple TV Channel ",
@@ -224,6 +240,14 @@ class StreamingServiceProvider < ActiveHash::Base
       tmdb_provider_id: 486,
       tmdb_logo_path: "/aAb9CUHjFe9Y3O57qnrJH0KOF1B.jpg",
       search_url: "https://ondemand.spectrum.net/search/?q="
+    },
+    {
+      id: "82527fd3-4aea-417f-b267-8eaa27a7e397",
+      display_name: "Tubi TV",
+      tmdb_provider_name: "Tubi TV",
+      tmdb_provider_id: 73,
+      tmdb_logo_path: "/zLYr7OPvpskMA4S79E3vlCi71iC.jpg",
+      search_url: "https://tubitv.com/search?q="
     },
     {
       id: "9c963ab2-5622-4592-ab33-b51a3c6d8d17",


### PR DESCRIPTION
## Problems Solved
We were not able to see Paramount+ info on movie and tv listings.  As I suspected, we just didn't have the most up-to-date provider info stored in our data. 

## This PR
* Adds the Paramount Plus subscription data so these options will appear for users to select in their settings
* Adds a couple of other providers as well

## Screenshots
Before: only showing Try options
<img width="713" height="490" alt="Screenshot 2026-05-04 at 9 40 09 AM" src="https://github.com/user-attachments/assets/5d41b817-10b1-437a-a531-769e29f78868" />

After: showing Paramount+ options
<img width="743" height="505" alt="Screenshot 2026-05-04 at 9 40 21 AM" src="https://github.com/user-attachments/assets/6ecc9da3-aed5-499c-a6ee-d94e7988d1d7" />

## Things Learned
When I built this originally, I made the streaming service provider data static so we could get an MVP up and running without thinking about database table requirements. So, the process for this fix was for me to manually search for content that I know is on Paramount then `pry` to see which providers are returned by the API. I then added them to the array. We may want to consider changing the implementation strategy to a table that gets updated either upon specific request calls or with a cron job so that we a least have access to new providers as they form in the API -- instead of us just wondering why nothing is appearing.

