### PR TITLE
Enable pgcrypto extension

### DIFF
--- a/db/migrate/20260729183539_enable_pgcrypto_extension.rb
+++ b/db/migrate/20260729183539_enable_pgcrypto_extension.rb
@@ -1,0 +1,5 @@
+class EnablePgcryptoExtension < ActiveRecord::Migration[7.2]
+  def change
+    enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_02_154214) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_29_183539) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "friendly_id_slugs", force: :cascade do |t|


### PR DESCRIPTION
## Problems Solved
* Enables the pgcrypto extension in our postgres database
* Resolves the problem in our test database where the extension is missing
* Should not harm production because the migration only enables the extension if it is not already enabled
* Works for both the schema load and migration setup approaches

## Things Learned
* This is part of a cascade of challenges in pulling apart the upgrade from 7.2 to 8.0
